### PR TITLE
Add docker volume support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Cargo storage management CLI/TUI
 * `clean` command with reasonable defaults
 * Support for `.cargo/config.toml` overrides. (best effort)
 * Support for both Cargo `build-dir` and `target-dir`
+* Optional `--docker` flag to also scan locally accessible Docker/Podman named volumes
 
 
 ## Installation
@@ -35,6 +36,10 @@ cargo storage list
 
 # Clean the target directories (defaults to older than 30d AND at least 100MB)
 cargo storage clean
+
+# Also scan Docker/Podman named volumes (needs read access to the volume
+# mountpoints; use sudo for rootful Docker)
+cargo shepherd list --docker
 
 # Run --help to see more options
 cargo storage --help

--- a/src/app.rs
+++ b/src/app.rs
@@ -64,6 +64,7 @@ impl App {
                     target_dir: found.target_dir,
                     kind: found.kind,
                     shared: found.shared,
+                    volume: found.volume,
                     size: None,
                     last_modified: None,
                 }
@@ -145,6 +146,7 @@ impl App {
                     re.is_match(&e.project_name())
                         || re.is_match(&e.project_path.to_string_lossy())
                         || re.is_match(&e.target_dir.to_string_lossy())
+                        || e.volume.as_deref().is_some_and(|v| re.is_match(v))
                 })
                 .map(|(i, _)| i)
                 .collect(),
@@ -179,12 +181,12 @@ impl App {
                 && m.last_modified.is_some()
             {
                 // The build cache arrived after startup, so give it a row now.
-                // The poller tracks it from the next reset.
                 self.build_cache = Some(TargetEntry {
                     project_path: m.target_dir.clone(),
                     target_dir: m.target_dir.clone(),
                     kind: crate::scan::OutputKind::Target,
                     shared: false,
+                    volume: None,
                     size: Some(m.size),
                     last_modified: m.last_modified,
                 });

--- a/src/args.rs
+++ b/src/args.rs
@@ -8,6 +8,10 @@ pub struct Args {
     /// Directory to scan. Defaults to the home directory.
     pub root: Option<PathBuf>,
 
+    /// Also scan locally accessible Docker/Podman named volumes.
+    #[arg(long)]
+    pub docker: bool,
+
     #[command(subcommand)]
     pub command: Option<Command>,
 }
@@ -18,16 +22,25 @@ pub enum Command {
     Tui {
         /// Directory to scan. Defaults to the home directory.
         root: Option<PathBuf>,
+        /// Also scan locally accessible Docker/Podman named volumes.
+        #[arg(long)]
+        docker: bool,
     },
     /// List target dirs on the system.
     List {
         /// Directory to scan. Defaults to the home directory.
         root: Option<PathBuf>,
+        /// Also scan locally accessible Docker/Podman named volumes.
+        #[arg(long)]
+        docker: bool,
     },
     /// Delete target dirs older than a max age and larger than a min size.
     Clean {
         /// Directory to scan. Defaults to the home directory.
         root: Option<PathBuf>,
+        /// Also scan locally accessible Docker/Podman named volumes.
+        #[arg(long)]
+        docker: bool,
         /// Only candidates older than this age match (e.g. 30d, 6mo, 1y).
         /// Defaults to 30d if no filters are given.
         #[arg(long)]
@@ -65,5 +78,33 @@ impl Args {
                 .flatten()
                 .unwrap_or_else(|| PathBuf::from("."))
         })
+    }
+
+    /// Whether `--docker` was passed either on the subcommand or top level.
+    pub fn docker_for(cmd_docker: bool, top_docker: bool) -> bool {
+        cmd_docker || top_docker
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use clap::Parser;
+
+    #[test]
+    fn docker_flag_parses_on_subcommands_and_top_level() {
+        let top = Args::try_parse_from(["shepherd", "--docker"]).unwrap();
+        assert!(top.docker);
+        assert!(top.command.is_none());
+        let list = Args::try_parse_from(["shepherd", "list", "--docker"]).unwrap();
+        assert!(matches!(
+            list.command,
+            Some(Command::List { docker: true, .. })
+        ));
+        // A top-level flag also enables subcommand scans.
+        let both = Args::try_parse_from(["shepherd", "--docker", "clean"]).unwrap();
+        assert!(both.docker);
+        assert!(Args::docker_for(false, both.docker));
+        assert!(!Args::docker_for(false, false));
     }
 }

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -1,6 +1,6 @@
 use std::{
     io::{self, Write},
-    path::Path,
+    path::PathBuf,
     time::{Duration, SystemTime},
 };
 
@@ -14,9 +14,13 @@ use crate::{
 };
 
 /// Blocking scan that reuses the TUI state for sorting and totals.
-fn collect(root: &Path) -> App {
-    let mut app = App::new(root.to_path_buf());
-    app.set_discovered(scan::discover(root));
+fn collect(roots: &[crate::scan::ScanRoot]) -> App {
+    let host = roots
+        .first()
+        .map(|r| r.path.clone())
+        .unwrap_or_else(|| PathBuf::from("."));
+    let mut app = App::new(host);
+    app.set_discovered(scan::discover_roots(roots));
     let measurements: Vec<_> = app
         .entries
         .par_iter()
@@ -29,17 +33,24 @@ fn collect(root: &Path) -> App {
 
 fn project_label(entry: &TargetEntry, entries: &[TargetEntry]) -> String {
     if let Some(shared) = entry.shared_label() {
-        return shared.to_string();
+        return match &entry.volume {
+            Some(volume) => format!("{shared} [docker:{volume}]"),
+            None => shared.to_string(),
+        };
     }
     let suffix = output_suffix(entry, entries)
         .map(|(label, _)| label)
         .unwrap_or("");
-    format!("{}{}", entry.project_name(), suffix)
+    let base = format!("{}{}", entry.project_name(), suffix);
+    match &entry.volume {
+        Some(volume) => format!("{base} [docker:{volume}]"),
+        None => base,
+    }
 }
 
 /// Print the TUI table rows as aligned text.
-pub fn run_list(root: &Path) -> Result<()> {
-    let app = collect(root);
+pub fn run_list(roots: &[crate::scan::ScanRoot]) -> Result<()> {
+    let app = collect(roots);
     let mut out = io::stdout().lock();
     if app.entries.is_empty() {
         writeln!(out, "No target/ directories found.")?;
@@ -109,7 +120,7 @@ fn render_table(out: &mut impl Write, shown: &[&TargetEntry], all: &[TargetEntry
 /// only passed filters constrain. With neither passed, fall back to older
 /// than 30d and larger than 100MB.
 pub fn run_clean(
-    root: &Path,
+    roots: &[crate::scan::ScanRoot],
     older_than: Option<&str>,
     larger_than: Option<&str>,
     yes: bool,
@@ -132,7 +143,7 @@ pub fn run_clean(
         .collect::<Vec<_>>()
         .join(" and ");
     let now = SystemTime::now();
-    let app = collect(root);
+    let app = collect(roots);
     let candidates: Vec<&TargetEntry> = app
         .entries
         .iter()
@@ -328,6 +339,7 @@ mod tests {
             target_dir: "proj/target".into(),
             kind: crate::scan::OutputKind::Target,
             shared: false,
+            volume: None,
             size,
             last_modified: age.map(|a| SystemTime::now() - a),
         }
@@ -376,7 +388,6 @@ mod tests {
             None
         ));
     }
-
     #[test]
     fn shared_entries_list_under_special_name() {
         let shared = TargetEntry {
@@ -384,10 +395,26 @@ mod tests {
             target_dir: "/shared".into(),
             kind: crate::scan::OutputKind::Target,
             shared: true,
+            volume: None,
             size: None,
             last_modified: None,
         };
         let rows = [shared.clone()];
         assert_eq!(project_label(&shared, &rows), "Shared Target Dir");
+    }
+
+    #[test]
+    fn volume_entries_carry_docker_label() {
+        let vol = TargetEntry {
+            project_path: "proj".into(),
+            target_dir: "/vols/v/proj/target".into(),
+            kind: crate::scan::OutputKind::Target,
+            shared: false,
+            volume: Some("v".to_string()),
+            size: None,
+            last_modified: None,
+        };
+        let rows = [vol.clone()];
+        assert_eq!(project_label(&vol, &rows), "proj [docker:v]");
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,8 +1,4 @@
-use std::{
-    path::{Path, PathBuf},
-    sync::mpsc,
-    time::Duration,
-};
+use std::{path::Path, sync::mpsc, time::Duration};
 
 use app::App;
 use args::{Args, Command};
@@ -18,7 +14,6 @@ use ratatui::Terminal;
 use ratatui::backend::CrosstermBackend;
 
 use poll::Poller;
-use scan::resolve_root;
 use ui::input::{Action, handle_key};
 
 use crate::util::cpu_count;
@@ -39,13 +34,32 @@ fn main() -> Result<()> {
     let _trace_guard = trace::init();
     let args = Args::parse_args();
     // TUI is the default when no subcommand is given.
-    let root = match &args.command {
-        None => Args::root_for(args.root.clone(), None),
-        Some(Command::Tui { root }) => Args::root_for(root.clone(), args.root.clone()),
-        Some(Command::List { root }) => {
-            let root = resolve_root(&Args::root_for(root.clone(), args.root.clone()));
-            check_root(&root)?;
-            let result = headless::run_list(&root);
+    match &args.command {
+        None => {
+            let host = Args::root_for(args.root.clone(), None);
+            let roots = scan::resolve_scan_roots(&host, args.docker)?;
+            check_root(&roots[0].path)?;
+            let result = tui(&roots);
+            if let Some(guard) = _trace_guard.as_ref() {
+                eprintln!("Trace written to {}", guard.path.display());
+            }
+            return result;
+        }
+        Some(Command::Tui { root, docker }) => {
+            let host = Args::root_for(root.clone(), args.root.clone());
+            let roots = scan::resolve_scan_roots(&host, Args::docker_for(*docker, args.docker))?;
+            check_root(&roots[0].path)?;
+            let result = tui(&roots);
+            if let Some(guard) = _trace_guard.as_ref() {
+                eprintln!("Trace written to {}", guard.path.display());
+            }
+            return result;
+        }
+        Some(Command::List { root, docker }) => {
+            let host = Args::root_for(root.clone(), args.root.clone());
+            let roots = scan::resolve_scan_roots(&host, Args::docker_for(*docker, args.docker))?;
+            check_root(&roots[0].path)?;
+            let result = headless::run_list(&roots);
             if let Some(guard) = _trace_guard.as_ref() {
                 eprintln!("Trace written to {}", guard.path.display());
             }
@@ -53,14 +67,16 @@ fn main() -> Result<()> {
         }
         Some(Command::Clean {
             root,
+            docker,
             older_than,
             larger_than,
             yes,
         }) => {
-            let root = resolve_root(&Args::root_for(root.clone(), args.root.clone()));
-            check_root(&root)?;
+            let host = Args::root_for(root.clone(), args.root.clone());
+            let roots = scan::resolve_scan_roots(&host, Args::docker_for(*docker, args.docker))?;
+            check_root(&roots[0].path)?;
             let result =
-                headless::run_clean(&root, older_than.as_deref(), larger_than.as_deref(), *yes);
+                headless::run_clean(&roots, older_than.as_deref(), larger_than.as_deref(), *yes);
             if let Some(guard) = _trace_guard.as_ref() {
                 eprintln!("Trace written to {}", guard.path.display());
             }
@@ -71,24 +87,21 @@ fn main() -> Result<()> {
             generate(*shell, &mut cmd, "cargo-storage", &mut std::io::stdout());
             return Ok(());
         }
-    };
-    let root = resolve_root(&root);
-    check_root(&root)?;
+    }
+}
 
+fn tui(roots: &[scan::ScanRoot]) -> Result<()> {
     enable_raw_mode().wrap_err("enabling terminal raw mode")?;
     let mut stdout = std::io::stdout();
     execute!(stdout, EnterAlternateScreen).wrap_err("entering alternate screen")?;
     let backend = CrosstermBackend::new(stdout);
     let mut terminal = Terminal::new(backend).wrap_err("creating terminal")?;
 
-    let result = run(&mut terminal, root);
+    let result = run(&mut terminal, roots);
 
     disable_raw_mode().wrap_err("disabling terminal raw mode")?;
     execute!(terminal.backend_mut(), LeaveAlternateScreen).wrap_err("leaving alternate screen")?;
     terminal.show_cursor().wrap_err("restoring cursor")?;
-    if let Some(guard) = _trace_guard.as_ref() {
-        eprintln!("Trace written to {}", guard.path.display());
-    }
 
     result
 }
@@ -100,9 +113,13 @@ fn check_root(root: &Path) -> Result<()> {
     Ok(())
 }
 
-fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf) -> Result<()> {
-    let mut app = App::new(root.clone());
-    let mut scan_rx = spawn_scan(&root);
+fn run(
+    terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>,
+    roots: &[scan::ScanRoot],
+) -> Result<()> {
+    let roots: Vec<scan::ScanRoot> = roots.to_vec();
+    let mut app = App::new(roots[0].path.clone());
+    let mut scan_rx = spawn_scan(&roots);
     let mut poller = Poller::new();
 
     loop {
@@ -149,7 +166,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
                     Action::Quit => return Ok(()),
                     Action::Rescan => {
                         app.begin_scan();
-                        scan_rx = spawn_scan(&app.root);
+                        scan_rx = spawn_scan(&roots);
                     }
                 },
                 Event::Resize(_, _) => {}
@@ -161,11 +178,11 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
 
 /// Run discovery plus the size walk off the UI thread. Discovery ships
 /// first so rows appear at once; sizes stream in after.
-fn spawn_scan(root: &Path) -> Option<mpsc::Receiver<scan::ScanEvent>> {
-    let root = root.to_path_buf();
+fn spawn_scan(roots: &[scan::ScanRoot]) -> Option<mpsc::Receiver<scan::ScanEvent>> {
+    let roots = roots.to_vec();
     let (tx, rx) = mpsc::channel();
     std::thread::spawn(move || {
-        scan::scan_stream(&root, tx);
+        scan::scan_stream_roots(&roots, tx);
     });
     Some(rx)
 }

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -31,6 +31,7 @@ pub fn build_cache_entry_at(path: &Path) -> Option<TargetEntry> {
         target_dir: path.to_path_buf(),
         kind: super::OutputKind::Target,
         shared: false,
+        volume: None,
         size: Some(size),
         last_modified,
     })

--- a/src/scan/cargo_config.rs
+++ b/src/scan/cargo_config.rs
@@ -215,6 +215,8 @@ pub struct DiscoveredEntry {
     pub kind: OutputKind,
     /// True when the dir came from `$CARGO_HOME/config.toml`.
     pub shared: bool,
+    /// Containing volume name for `--docker` hits, else `None`.
+    pub volume: Option<String>,
 }
 
 impl DiscoveredEntry {
@@ -224,10 +226,10 @@ impl DiscoveredEntry {
             target_dir,
             kind,
             shared,
+            volume: None,
         }
     }
 }
-
 /// Bare manifest dirs default to a sibling `target/`.
 impl From<PathBuf> for DiscoveredEntry {
     fn from(project_path: PathBuf) -> Self {
@@ -237,6 +239,7 @@ impl From<PathBuf> for DiscoveredEntry {
             target_dir,
             kind: OutputKind::Target,
             shared: false,
+            volume: None,
         }
     }
 }

--- a/src/scan/discover.rs
+++ b/src/scan/discover.rs
@@ -18,7 +18,7 @@ use rayon::prelude::*;
 use crate::util::cpu_count;
 
 use super::{
-    TargetEntry,
+    ScanRoot, TargetEntry,
     cargo_config::{DiscoveredEntry, Resolver},
     measure::{Measurement, measure_target},
 };
@@ -46,12 +46,6 @@ struct Ctx {
     /// entirely while no customs exist.
     has_customs: AtomicBool,
     manifests: Mutex<Vec<PathBuf>>,
-}
-
-/// Find project/output pairs without measuring them.
-#[tracing::instrument(skip_all, fields(root = %root.display()))]
-pub fn discover(root: &Path) -> Vec<DiscoveredEntry> {
-    discover_with(root, Resolver::new())
 }
 
 /// Test seam: disk fixtures fully determine the result.
@@ -98,6 +92,36 @@ pub(crate) fn discover_with(root: &Path, mut resolver: Resolver) -> Vec<Discover
             }
         }
     }
+    sort_and_dedup(entries)
+}
+
+/// Find project/output pairs across the host root plus volume roots.
+/// Roots missing from disk are skipped. One row per output dir survives,
+/// host roots first so a volume overlapping the host keeps the host label.
+pub fn discover_roots(roots: &[ScanRoot]) -> Vec<DiscoveredEntry> {
+    discover_roots_with(roots, Resolver::new)
+}
+
+/// Test seam: disk fixtures fully determine the result.
+pub(crate) fn discover_roots_with(
+    roots: &[ScanRoot],
+    make_resolver: impl Fn() -> Resolver,
+) -> Vec<DiscoveredEntry> {
+    let mut entries = Vec::new();
+    for root in roots {
+        if !root.path.is_dir() {
+            continue;
+        }
+        let mut found = discover_with(&root.path, make_resolver());
+        for entry in &mut found {
+            entry.volume = root.volume.clone();
+        }
+        entries.extend(found);
+    }
+    sort_and_dedup(entries)
+}
+
+fn sort_and_dedup(mut entries: Vec<DiscoveredEntry>) -> Vec<DiscoveredEntry> {
     entries.sort_by(|a, b| {
         a.project_path
             .cmp(&b.project_path)
@@ -114,14 +138,33 @@ pub(crate) fn discover_with(root: &Path, mut resolver: Resolver) -> Vec<Discover
     entries
 }
 
-/// Discover then measure, streaming progress over `tx`.
-pub fn scan_stream(root: &Path, tx: mpsc::Sender<ScanEvent>) {
-    scan_stream_with(root, tx, Resolver::new());
+/// Test seam: disk fixtures fully determine the result.
+#[cfg(test)]
+pub(crate) fn scan_stream_with(root: &Path, tx: mpsc::Sender<ScanEvent>, resolver: Resolver) {
+    let projects = discover_with(root, resolver);
+    if tx.send(ScanEvent::Discovered(projects.clone())).is_err() {
+        return;
+    }
+    projects.par_iter().for_each_with(tx.clone(), |tx, entry| {
+        let m = measure_target(&entry.target_dir);
+        let _ = tx.send(ScanEvent::Measured(m));
+    });
+    let build_cache = super::cache::build_cache_entry();
+    let _ = tx.send(ScanEvent::Done { build_cache });
+}
+
+/// Discover across roots then measure, streaming progress over `tx`.
+pub fn scan_stream_roots(roots: &[ScanRoot], tx: mpsc::Sender<ScanEvent>) {
+    scan_stream_roots_with(roots, tx, Resolver::new);
 }
 
 /// Test seam: disk fixtures fully determine the result.
-pub(crate) fn scan_stream_with(root: &Path, tx: mpsc::Sender<ScanEvent>, resolver: Resolver) {
-    let projects = discover_with(root, resolver);
+pub(crate) fn scan_stream_roots_with(
+    roots: &[ScanRoot],
+    tx: mpsc::Sender<ScanEvent>,
+    make_resolver: impl Fn() -> Resolver + Sync,
+) {
+    let projects = discover_roots_with(roots, make_resolver);
     if tx.send(ScanEvent::Discovered(projects.clone())).is_err() {
         return;
     }
@@ -460,5 +503,42 @@ mod tests {
         )));
         assert!(matches!(events.last(), Some(ScanEvent::Done { .. })));
         let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn roots_merge_with_volume_tags_and_skip_missing() {
+        let base = std::env::temp_dir().join("cargo-shepherd-test-multi-root");
+        let _ = fs::remove_dir_all(&base);
+        for proj in ["host-proj", "vol-proj"] {
+            fs::create_dir_all(base.join(proj).join("target")).unwrap();
+            fs::write(base.join(proj).join("Cargo.toml"), "[package]\n").unwrap();
+        }
+        let roots = vec![
+            ScanRoot::host(base.clone()),
+            ScanRoot {
+                path: base.clone(),
+                volume: Some("vol-a".to_string()),
+            },
+            ScanRoot::host(base.join("gone")),
+        ];
+        let found = discover_roots_with(&roots, Resolver::hermetic);
+        // Same `target/` dirs collapse to one row; the host root sorts first
+        // so overlapping hits keep the host label.
+        assert_eq!(found.len(), 2);
+        assert!(found.iter().all(|e| e.volume.is_none()));
+        let vol_only = discover_roots_with(
+            &[ScanRoot {
+                path: base.clone(),
+                volume: Some("vol-a".to_string()),
+            }],
+            Resolver::hermetic,
+        );
+        assert_eq!(vol_only.len(), 2);
+        assert!(
+            vol_only
+                .iter()
+                .all(|e| e.volume.as_deref() == Some("vol-a"))
+        );
+        let _ = fs::remove_dir_all(&base);
     }
 }

--- a/src/scan/docker.rs
+++ b/src/scan/docker.rs
@@ -1,0 +1,208 @@
+//! Named container volumes as extra scan roots.
+//!
+//! Listing goes through the `docker` (or `podman`) CLI so remote daemons,
+//! rootless storage, and `DOCKER_HOST` keep working. Only mountpoints that
+//! are local dirs are walked. The rest are reported as warnings.
+
+use std::path::PathBuf;
+use std::process::Command;
+
+/// One named volume and its host-side mountpoint.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct DockerVolume {
+    pub name: String,
+    pub mountpoint: PathBuf,
+}
+
+/// One walk root. `volume` is the volume name for container roots,
+/// `None` for the plain host root.
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub struct ScanRoot {
+    pub path: PathBuf,
+    pub volume: Option<String>,
+}
+
+impl ScanRoot {
+    pub fn host(path: PathBuf) -> Self {
+        Self { path, volume: None }
+    }
+}
+
+impl From<PathBuf> for ScanRoot {
+    fn from(path: PathBuf) -> Self {
+        Self::host(path)
+    }
+}
+
+/// List all named volumes via the container runtime.
+pub fn list_volumes() -> eyre::Result<Vec<DockerVolume>> {
+    let rt = select_runtime()?;
+    let ls = Command::new(rt)
+        .args(["volume", "ls", "-q"])
+        .output()
+        .map_err(|e| eyre::eyre!("running `{rt} volume ls`: {e}"))?;
+    if !ls.status.success() {
+        let detail = String::from_utf8_lossy(&ls.stderr).trim().to_string();
+        eyre::bail!("`{rt} volume ls` failed: {detail}");
+    }
+    let ls_text = String::from_utf8_lossy(&ls.stdout).into_owned();
+    let names: Vec<&str> = ls_text
+        .lines()
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .collect();
+    if names.is_empty() {
+        return Ok(Vec::new());
+    }
+    let mut cmd = Command::new(rt);
+    cmd.args([
+        "volume",
+        "inspect",
+        "--format",
+        "{{.Name}}\t{{.Mountpoint}}",
+    ]);
+    for name in &names {
+        cmd.arg(name);
+    }
+    let out = cmd
+        .output()
+        .map_err(|e| eyre::eyre!("running `{rt} volume inspect`: {e}"))?;
+    if !out.status.success() {
+        let detail = String::from_utf8_lossy(&out.stderr).trim().to_string();
+        eyre::bail!("`{rt} volume inspect` failed: {detail}");
+    }
+    Ok(parse_inspect_output(&String::from_utf8_lossy(&out.stdout)))
+}
+
+/// Split volume roots into walkable dirs and human-readable warnings.
+/// Non-local (remote daemon, Desktop VM) and unreadable mountpoints land
+/// in warnings so one bad volume never fails the whole scan.
+pub fn usable_roots(volumes: &[DockerVolume]) -> (Vec<ScanRoot>, Vec<String>) {
+    let mut roots = Vec::new();
+    let mut skipped = Vec::new();
+    for vol in volumes {
+        if vol.mountpoint.is_dir() {
+            roots.push(ScanRoot {
+                path: vol.mountpoint.clone(),
+                volume: Some(vol.name.clone()),
+            });
+            continue;
+        }
+        skipped.push(skip_reason(vol));
+    }
+    (roots, skipped)
+}
+
+fn skip_reason(vol: &DockerVolume) -> String {
+    match std::fs::symlink_metadata(&vol.mountpoint) {
+        Err(e) if e.kind() == std::io::ErrorKind::PermissionDenied => format!(
+            "--docker: skipping volume `{}`: permission denied on {} (try sudo)",
+            vol.name,
+            vol.mountpoint.display()
+        ),
+        Err(e) => format!(
+            "--docker: skipping volume `{}`: cannot access {} ({e}); \
+             the daemon may be remote",
+            vol.name,
+            vol.mountpoint.display()
+        ),
+        Ok(_) => format!(
+            "--docker: skipping volume `{}`: not a directory: {}",
+            vol.name,
+            vol.mountpoint.display()
+        ),
+    }
+}
+
+/// Prefer docker, fall back to podman only when docker is not installed.
+/// A present-but-broken docker (daemon down) reports its own error rather
+/// than silently returning podman's volumes.
+fn select_runtime() -> eyre::Result<&'static str> {
+    if have_binary("docker") {
+        return Ok("docker");
+    }
+    if have_binary("podman") {
+        return Ok("podman");
+    }
+    eyre::bail!("--docker needs a container runtime: neither `docker` nor `podman` found in PATH")
+}
+
+fn have_binary(rt: &str) -> bool {
+    Command::new(rt).arg("--version").output().is_ok()
+}
+
+/// Parse `volume inspect --format` lines. Malformed lines are skipped.
+fn parse_inspect_output(text: &str) -> Vec<DockerVolume> {
+    let mut volumes = Vec::new();
+    for line in text.lines() {
+        let line = line.trim();
+        if line.is_empty() {
+            continue;
+        }
+        let (name, mount) = match line.split_once('\t').or_else(|| line.split_once(' ')) {
+            Some(pair) => pair,
+            None => continue,
+        };
+        let (name, mount) = (name.trim(), mount.trim());
+        if name.is_empty() || mount.is_empty() {
+            continue;
+        }
+        volumes.push(DockerVolume {
+            name: name.to_string(),
+            mountpoint: PathBuf::from(mount),
+        });
+    }
+    volumes.sort_by(|a, b| a.name.cmp(&b.name));
+    volumes
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn parses_tabbed_inspect_lines_in_name_order() {
+        let out = parse_inspect_output(
+            "zeta\t/var/lib/docker/volumes/zeta/_data\n\
+             alpha\t/var/lib/docker/volumes/alpha/_data\n",
+        );
+        assert_eq!(
+            out.iter().map(|v| v.name.clone()).collect::<Vec<_>>(),
+            vec!["alpha".to_string(), "zeta".to_string()]
+        );
+        assert_eq!(
+            out[0].mountpoint,
+            PathBuf::from("/var/lib/docker/volumes/alpha/_data")
+        );
+    }
+
+    #[test]
+    fn skips_blank_and_malformed_lines() {
+        let out = parse_inspect_output("lonely-name\n\nok\t/data\n  \n");
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].name, "ok");
+    }
+
+    #[test]
+    fn usable_roots_keeps_local_dirs_and_warns_on_missing() {
+        let root = std::env::temp_dir().join("cargo-shepherd-test-docker-roots");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("vol-a/_data")).unwrap();
+        let volumes = vec![
+            DockerVolume {
+                name: "vol-a".to_string(),
+                mountpoint: root.join("vol-a/_data"),
+            },
+            DockerVolume {
+                name: "gone".to_string(),
+                mountpoint: root.join("gone/_data"),
+            },
+        ];
+        let (roots, skipped) = usable_roots(&volumes);
+        assert_eq!(roots.len(), 1);
+        assert_eq!(roots[0].volume.as_deref(), Some("vol-a"));
+        assert_eq!(skipped.len(), 1);
+        assert!(skipped[0].contains("gone"));
+        let _ = std::fs::remove_dir_all(&root);
+    }
+}

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -5,11 +5,13 @@
 mod cache;
 mod cargo_config;
 mod discover;
+mod docker;
 mod measure;
 
 pub use cache::{build_cache_entry, build_cache_path};
 pub use cargo_config::{DiscoveredEntry, OutputKind};
-pub use discover::{ScanEvent, discover, scan_stream};
+pub use discover::{ScanEvent, discover_roots, scan_stream_roots};
+pub use docker::{ScanRoot, list_volumes, usable_roots};
 pub use measure::{Measurement, measure_target};
 
 use std::{
@@ -28,6 +30,8 @@ pub struct TargetEntry {
     pub kind: OutputKind,
     /// True when the dir came from `$CARGO_HOME/config.toml`.
     pub shared: bool,
+    /// Containing volume name for `--docker` hits, else `None`.
+    pub volume: Option<String>,
     /// Disk usage of `target_dir` in bytes, `du` semantics. `None` while
     /// the size walk has not measured this entry yet.
     pub size: Option<u64>,
@@ -58,4 +62,28 @@ impl TargetEntry {
 
 pub fn resolve_root(raw: &Path) -> PathBuf {
     std::fs::canonicalize(raw).unwrap_or_else(|_| raw.to_path_buf())
+}
+
+/// Walk roots for a scan: the host root plus locally accessible volume
+/// mountpoints when `include_docker` is set. Skipped volumes warn on
+/// stderr. Daemon failures bail so `--docker` never silently scans host only.
+pub fn resolve_scan_roots(host: &Path, include_docker: bool) -> eyre::Result<Vec<ScanRoot>> {
+    let mut roots = vec![ScanRoot::host(resolve_root(host))];
+    if !include_docker {
+        return Ok(roots);
+    }
+    let volumes = list_volumes()?;
+    if volumes.is_empty() {
+        eprintln!("--docker: no container volumes found");
+        return Ok(roots);
+    }
+    let (mut usable, skipped) = usable_roots(&volumes);
+    for line in &skipped {
+        eprintln!("{line}");
+    }
+    for root in &mut usable {
+        root.path = resolve_root(&root.path);
+    }
+    roots.append(&mut usable);
+    Ok(roots)
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -311,11 +311,24 @@ pub(crate) fn project_spans(
             crate::scan::OutputKind::Target => Color::Green,
             crate::scan::OutputKind::Build => Color::Blue,
         };
-        return vec![Span::styled(shared, base.fg(color))];
+        let mut spans = vec![Span::styled(shared, base.fg(color))];
+        if let Some(volume) = &entry.volume {
+            spans.push(Span::styled(
+                format!(" [docker:{volume}]"),
+                Style::default().fg(Color::Cyan),
+            ));
+        }
+        return spans;
     }
     let mut spans = vec![Span::styled(entry.project_name(), base)];
     if let Some((label, color)) = output_suffix(entry, entries) {
         spans.push(Span::styled(label, Style::default().fg(color)));
+    }
+    if let Some(volume) = &entry.volume {
+        spans.push(Span::styled(
+            format!(" [docker:{volume}]"),
+            Style::default().fg(Color::Cyan),
+        ));
     }
     spans
 }
@@ -509,6 +522,7 @@ mod tests {
             target_dir: std::path::PathBuf::from("proj-a/target"),
             kind: crate::scan::OutputKind::Target,
             shared: false,
+            volume: None,
             size: None,
             last_modified: None,
         };
@@ -522,6 +536,7 @@ mod tests {
             target_dir: std::path::PathBuf::from(dir),
             kind,
             shared: false,
+            volume: None,
             size: None,
             last_modified: None,
         };
@@ -547,6 +562,7 @@ mod tests {
             target_dir: std::path::PathBuf::from("proj/target"),
             kind: OutputKind::Target,
             shared: false,
+            volume: None,
             size: None,
             last_modified: None,
         };
@@ -566,6 +582,7 @@ mod tests {
             target_dir: std::path::PathBuf::from("/shared"),
             kind,
             shared: true,
+            volume: None,
             size: None,
             last_modified: None,
         };
@@ -587,12 +604,12 @@ mod tests {
     #[test]
     fn shared_cells_render_name_in_per_kind_color() {
         use crate::scan::{OutputKind, TargetEntry};
-        use ratatui::style::Style;
         let entry = |kind: OutputKind| TargetEntry {
             project_path: std::path::PathBuf::from("proj"),
             target_dir: std::path::PathBuf::from("/shared"),
             kind,
             shared: true,
+            volume: None,
             size: None,
             last_modified: None,
         };
@@ -606,6 +623,25 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content.as_ref(), "Shared Build Dir");
         assert_eq!(spans[0].style.fg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn volume_entries_append_docker_tag() {
+        use crate::scan::{OutputKind, TargetEntry};
+        use ratatui::style::Style;
+        let vol = TargetEntry {
+            project_path: std::path::PathBuf::from("proj"),
+            target_dir: std::path::PathBuf::from("proj/target"),
+            kind: OutputKind::Target,
+            shared: false,
+            volume: Some("v".to_string()),
+            size: None,
+            last_modified: None,
+        };
+        let spans = project_spans(&vol, std::slice::from_ref(&vol), Style::default());
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[1].content.as_ref(), " [docker:v]");
+        assert_eq!(spans[1].style.fg, Some(Color::Cyan));
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added optional Docker/Podman volume scanning with the `--docker` flag for listing, cleaning, and interactive views.
  * Scans accessible local named volumes and combines results with the host scan.
  * Displays the associated Docker volume alongside discovered projects.
  * Filters now also match Docker volume names.

* **Documentation**
  * Added `--docker` usage examples and noted required volume read permissions, including sudo for rootful Docker.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->