### PR TITLE
native worktree support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /target
 cargo-storage-trace.json
+.ignored

--- a/src/app.rs
+++ b/src/app.rs
@@ -143,6 +143,7 @@ impl App {
                 .enumerate()
                 .filter(|(_, e)| {
                     re.is_match(&e.project_name())
+                        || re.is_match(&e.display_name())
                         || re.is_match(&e.project_path.to_string_lossy())
                         || re.is_match(&e.target_dir.to_string_lossy())
                 })

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -34,7 +34,7 @@ fn project_label(entry: &TargetEntry, entries: &[TargetEntry]) -> String {
     let suffix = output_suffix(entry, entries)
         .map(|(label, _)| label)
         .unwrap_or("");
-    format!("{}{}", entry.project_name(), suffix)
+    format!("{}{}", entry.display_name(), suffix)
 }
 
 /// Print the TUI table rows as aligned text.

--- a/src/scan/discover.rs
+++ b/src/scan/discover.rs
@@ -1,7 +1,9 @@
 //! Find Rust projects and measure their output dirs. Discovery walks in
 //! parallel and honors ignore files, except gitignored `target/` dirs,
-//! which still measure. Projects with `build.target-dir` /
-//! `build.build-dir` in `.cargo/config.toml` report those dirs instead of
+//! which still measure, and linked git worktrees, which are walked even
+//! when a parent ignore file prunes them. Projects with
+//! `build.target-dir` / `build.build-dir` in `.cargo/config.toml` report
+//! those dirs instead of `target/`.
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -46,16 +48,82 @@ struct Ctx {
     /// entirely while no customs exist.
     has_customs: AtomicBool,
     manifests: Mutex<Vec<PathBuf>>,
+    /// Dirs holding `.git` seen by the main walk. Each is queried for
+    /// linked worktrees after the walk, so ancestor scans (e.g. home)
+    /// find worktrees of nested repos, not just the scan root's own repo.
+    repos: Mutex<Vec<PathBuf>>,
 }
-
-/// Find project/output pairs without measuring them.
 #[tracing::instrument(skip_all, fields(root = %root.display()))]
 pub fn discover(root: &Path) -> Vec<DiscoveredEntry> {
     discover_with(root, Resolver::new())
 }
 
-/// Test seam: disk fixtures fully determine the result.
-pub(crate) fn discover_with(root: &Path, mut resolver: Resolver) -> Vec<DiscoveredEntry> {
+/// Find project/output pairs without measuring them.
+///
+/// Linked worktrees under `root` are walked explicitly, so a worktree in
+/// a gitignored dir (e.g. `.ignored/trees/t1`) is still discovered.
+/// Anything git reports outside `root` stays out of scope.
+pub(crate) fn discover_with(root: &Path, resolver: Resolver) -> Vec<DiscoveredEntry> {
+    let ctx = walk_ctx(root, resolver);
+    // The root query covers `scan <repo>`; per-repo queries cover ancestor
+    // scans (e.g. home), where the root itself is not a repo.
+    let mut candidates = worktree_list(root);
+    let mut repos: Vec<PathBuf> = ctx
+        .repos
+        .lock()
+        .map(|mut repos| std::mem::take(&mut *repos))
+        .unwrap_or_default();
+    repos.sort();
+    repos.dedup();
+    candidates.extend(
+        repos
+            .par_iter()
+            .flat_map(|repo| worktree_list(repo))
+            .collect::<Vec<_>>(),
+    );
+    let mut covered = repos;
+    covered.push(root.to_path_buf());
+    if let Ok(canonical) = std::fs::canonicalize(root) {
+        covered.push(canonical);
+    }
+    for extra in select_worktrees(candidates, root, &covered) {
+        run_walk(&extra, &ctx);
+    }
+    finish(ctx)
+}
+
+/// Test seam: `extra_roots` are walked alongside `root` with the same
+/// filters, so fixtures fully determine the result without needing git.
+#[cfg(test)]
+pub(crate) fn discover_with_extra(
+    root: &Path,
+    resolver: Resolver,
+    extra_roots: &[PathBuf],
+) -> Vec<DiscoveredEntry> {
+    let ctx = walk_ctx(root, resolver);
+    // A parent ignore file may prune these paths from the main walk, so
+    // each gets its own walk rooted inside the ignored dir. Walking from
+    // the worktree itself bypasses the parent's ignore rules.
+    let canonical_root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let mut extras: Vec<&PathBuf> = extra_roots
+        .iter()
+        .filter(|p| {
+            let mine = *p != root && *p != &canonical_root;
+            mine && (p.starts_with(root) || p.starts_with(&canonical_root))
+        })
+        .collect();
+    extras.sort();
+    extras.dedup();
+    for extra in extras {
+        if extra.is_dir() {
+            run_walk(extra, &ctx);
+        }
+    }
+    finish(ctx)
+}
+
+/// Shared walk setup plus the main walk over `root`.
+fn walk_ctx(root: &Path, mut resolver: Resolver) -> Arc<Ctx> {
     let customs: HashSet<PathBuf> = resolver
         .outer_dirs(root)
         .into_iter()
@@ -66,27 +134,20 @@ pub(crate) fn discover_with(root: &Path, mut resolver: Resolver) -> Vec<Discover
         has_customs: AtomicBool::new(!customs.is_empty()),
         customs: RwLock::new(customs),
         manifests: Mutex::new(Vec::new()),
+        repos: Mutex::new(Vec::new()),
     });
-    WalkBuilder::new(root)
-        // Hidden dirs may hold projects; `.git` and `.cargo` are pruned below.
-        .hidden(false)
-        // Apply gitignores even outside a git checkout.
-        .require_git(false)
-        .threads(cpu_count())
-        .filter_entry({
-            let ctx = Arc::clone(&ctx);
-            move |entry| keep_entry(entry, &ctx)
-        })
-        .build_parallel()
-        .run(|| {
-            let ctx = Arc::clone(&ctx);
-            Box::new(move |result: Result<DirEntry, ignore::Error>| visit_entry(result, &ctx))
-        });
+    run_walk(root, &ctx);
+    ctx
+}
+
+/// Resolve collected manifests into one row per output dir.
+fn finish(ctx: Arc<Ctx>) -> Vec<DiscoveredEntry> {
     let Ctx {
         resolver,
         customs: _,
         has_customs: _,
         manifests,
+        repos: _,
     } = Arc::try_unwrap(ctx).map_err(|_| ()).expect("walk done");
     let manifests = manifests.into_inner().unwrap_or_default();
     let mut resolver = resolver.into_inner().unwrap_or_else(|_| Resolver::new());
@@ -110,8 +171,94 @@ pub(crate) fn discover_with(root: &Path, mut resolver: Resolver) -> Vec<Discover
     // so keep the first row per dir.
     let mut seen = HashSet::new();
     entries.retain(|e| seen.insert(e.target_dir.clone()));
+    // A manifest reachable from both the main walk and a worktree walk
+    // (e.g. once an ignore is lifted) resolves to the same rows, so drop
+    // exact duplicates here rather than in the hot walk path.
+    entries.dedup();
     tracing::info!(count = entries.len(), "discovery complete");
     entries
+}
+
+fn normalize_path(path: &Path) -> PathBuf {
+    std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+}
+
+/// Worktree candidates under `root`, minus already-walked dirs.
+fn select_worktrees(candidates: Vec<PathBuf>, root: &Path, covered: &[PathBuf]) -> Vec<PathBuf> {
+    let canonical_root = normalize_path(root);
+    let covered: Vec<PathBuf> = covered.iter().map(|c| normalize_path(c)).collect();
+    let mut extras: Vec<PathBuf> = candidates
+        .into_iter()
+        .map(|p| normalize_path(&p))
+        .filter(|p| {
+            (p.starts_with(&canonical_root) || p.starts_with(root))
+                && !covered.iter().any(|c| p == c)
+                && p.is_dir()
+        })
+        .collect();
+    extras.sort();
+    extras.dedup();
+    extras
+}
+
+/// One parallel walk over `root`, recording manifest dirs in `ctx`.
+fn run_walk(root: &Path, ctx: &Arc<Ctx>) {
+    WalkBuilder::new(root)
+        // Hidden dirs may hold projects; `.git` and `.cargo` are pruned below.
+        .hidden(false)
+        // Apply gitignores even outside a git checkout.
+        .require_git(false)
+        .threads(cpu_count())
+        .filter_entry({
+            let ctx = Arc::clone(ctx);
+            move |entry| keep_entry(entry, &ctx)
+        })
+        .build_parallel()
+        .run(|| {
+            let ctx = Arc::clone(ctx);
+            Box::new(move |result: Result<DirEntry, ignore::Error>| visit_entry(result, &ctx))
+        });
+}
+
+/// `git worktree list --porcelain` paths for one repo dir, unfiltered.
+/// Best effort: not a repo, no git binary, or any failure yields empty,
+/// and discovery falls back to the plain walk.
+fn worktree_list(repo: &Path) -> Vec<PathBuf> {
+    let output = std::process::Command::new("git")
+        .arg("-C")
+        .arg(repo)
+        .args(["worktree", "list", "--porcelain", "-z"])
+        .output();
+    let Ok(output) = output else {
+        return Vec::new();
+    };
+    if !output.status.success() {
+        return Vec::new();
+    }
+    let mut worktrees = Vec::new();
+    for field in output.stdout.split(|&b| b == 0) {
+        let line = std::str::from_utf8(field).unwrap_or_default();
+        let Some(raw) = line.strip_prefix("worktree ") else {
+            continue;
+        };
+        let path = normalize_path(&PathBuf::from(unquote_worktree_path(raw)));
+        if !worktrees.contains(&path) {
+            worktrees.push(path);
+        }
+    }
+    worktrees
+}
+
+/// Unquote a `--porcelain` path, which git double-quotes when it holds
+/// special bytes. Anything else passes through untouched.
+fn unquote_worktree_path(raw: &str) -> String {
+    if raw.len() >= 2 && raw.starts_with('"') && raw.ends_with('"') {
+        raw[1..raw.len() - 1]
+            .replace("\\\"", "\"")
+            .replace("\\\\", "\\")
+    } else {
+        raw.to_owned()
+    }
 }
 
 /// Discover then measure, streaming progress over `tx`.
@@ -187,6 +334,14 @@ fn visit_entry(result: Result<DirEntry, ignore::Error>, ctx: &Ctx) -> WalkState 
         return WalkState::Continue;
     }
     let dir = entry.path();
+    // Any checkout (main or linked) advertises its repo with `.git`.
+    // Repos seen here are queried for linked worktrees after the walk,
+    // so ancestor scans find worktrees of nested repos too.
+    if std::fs::symlink_metadata(dir.join(".git")).is_ok() {
+        if let Ok(mut repos) = ctx.repos.lock() {
+            repos.push(dir.to_path_buf());
+        }
+    }
     if !is_manifest_dir(dir) {
         return WalkState::Continue;
     }
@@ -258,10 +413,25 @@ mod tests {
         root
     }
 
+    fn canonical_path(path: &Path) -> PathBuf {
+        std::fs::canonicalize(path).unwrap_or_else(|_| path.to_path_buf())
+    }
+
     fn projects_of(entries: &[DiscoveredEntry]) -> Vec<PathBuf> {
         let mut projects: Vec<PathBuf> = entries.iter().map(|e| e.project_path.clone()).collect();
         projects.sort();
         projects
+    }
+
+    fn expect_projects(entries: &[DiscoveredEntry], expected: &[PathBuf]) {
+        let mut actual: Vec<PathBuf> = entries
+            .iter()
+            .map(|e| canonical_path(&e.project_path))
+            .collect();
+        actual.sort();
+        let mut want: Vec<PathBuf> = expected.iter().map(|p| canonical_path(p)).collect();
+        want.sort();
+        assert_eq!(actual, want);
     }
 
     #[test]
@@ -459,6 +629,112 @@ mod tests {
                 if m.target_dir == root.join("proj-a/target") && m.size >= 5
         )));
         assert!(matches!(events.last(), Some(ScanEvent::Done { .. })));
+        let _ = fs::remove_dir_all(&root);
+    }
+    #[test]
+    fn extra_root_rescues_project_from_gitignored_dir() {
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-extra");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        fs::write(root.join(".gitignore"), "trees/\n").unwrap();
+        fs::create_dir_all(root.join("trees/wt/target")).unwrap();
+        fs::write(root.join("trees/wt/Cargo.toml"), "[package]\n").unwrap();
+        fs::write(root.join("trees/wt/target/blob.bin"), "hello").unwrap();
+
+        // Main walk alone never descends into the ignored dir.
+        assert!(discover(&root).is_empty());
+        // An explicit worktree walk starts inside it, bypassing the parent rule.
+        let projects = discover_with_extra(&root, Resolver::hermetic(), &[root.join("trees/wt")]);
+        expect_projects(&projects, &[root.join("trees/wt")]);
+        assert_eq!(projects[0].target_dir, root.join("trees/wt/target"));
+        // Roots outside the scan stay out of scope even when listed.
+        let outside = std::env::temp_dir().join("cargo-storage-test-wt-outside");
+        let projects = discover_with_extra(&root, Resolver::hermetic(), &[outside]);
+        assert!(projects.is_empty());
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn git_worktree_in_ignored_dir_is_discovered() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-git");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(&root).unwrap();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&root)
+                .args(args)
+                .status()
+                .expect("git runs");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "test"]);
+        git(&["commit", "--allow-empty", "-m", "init"]);
+        fs::write(root.join(".gitignore"), "trees/\n").unwrap();
+        git(&["worktree", "add", "--detach", "trees/wt"]);
+        // Ordinary ignored project: still skipped.
+        fs::create_dir_all(root.join("trees/ghost/target")).unwrap();
+        fs::write(root.join("trees/ghost/Cargo.toml"), "[package]\n").unwrap();
+        // Linked worktree project: found despite the parent ignore.
+        fs::create_dir_all(root.join("trees/wt/target")).unwrap();
+        fs::write(root.join("trees/wt/Cargo.toml"), "[package]\n").unwrap();
+        fs::write(root.join("trees/wt/target/blob.bin"), "hello").unwrap();
+
+        let projects = discover(&root);
+        expect_projects(&projects, &[root.join("trees/wt")]);
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn ancestor_scan_finds_nested_repo_worktree() {
+        if std::process::Command::new("git")
+            .arg("--version")
+            .output()
+            .is_err()
+        {
+            return;
+        }
+        // Scan root is not a repo; the repo nested inside holds an
+        // ignored worktree. This is the `list` (home dir) shape.
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-ancestor");
+        let _ = fs::remove_dir_all(&root);
+        let repo = root.join("repo");
+        fs::create_dir_all(&repo).unwrap();
+        let git = |args: &[&str]| {
+            let status = std::process::Command::new("git")
+                .arg("-C")
+                .arg(&repo)
+                .args(args)
+                .status()
+                .expect("git runs");
+            assert!(status.success(), "git {args:?} failed");
+        };
+        git(&["init", "-b", "main"]);
+        git(&["config", "user.email", "test@example.com"]);
+        git(&["config", "user.name", "test"]);
+        git(&["commit", "--allow-empty", "-m", "init"]);
+        fs::write(repo.join(".gitignore"), "trees/\n").unwrap();
+        git(&["worktree", "add", "--detach", "trees/wt"]);
+        fs::create_dir_all(repo.join("proj/target")).unwrap();
+        fs::write(repo.join("proj/Cargo.toml"), "[package]\n").unwrap();
+        fs::write(repo.join("proj/target/blob.bin"), "hello").unwrap();
+        fs::create_dir_all(repo.join("trees/ghost/target")).unwrap();
+        fs::write(repo.join("trees/ghost/Cargo.toml"), "[package]\n").unwrap();
+        fs::create_dir_all(repo.join("trees/wt/target")).unwrap();
+        fs::write(repo.join("trees/wt/Cargo.toml"), "[package]\n").unwrap();
+        fs::write(repo.join("trees/wt/target/blob.bin"), "hello").unwrap();
+
+        let projects = discover(&root);
+        expect_projects(&projects, &[repo.join("proj"), repo.join("trees/wt")]);
         let _ = fs::remove_dir_all(&root);
     }
 }

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -1,6 +1,7 @@
 //! Find Rust projects and measure their `target/` dirs. Discovery walks in
 //! parallel and honors ignore files, except gitignored `target/` dirs,
-//! which still measure.
+//! which still measure, and linked git worktrees, which are walked even
+//! from inside gitignored dirs.
 
 mod cache;
 mod cargo_config;
@@ -13,7 +14,7 @@ pub use discover::{ScanEvent, discover, scan_stream};
 pub use measure::{Measurement, measure_target};
 
 use std::{
-    path::{Path, PathBuf},
+    path::{Component, Path, PathBuf},
     time::SystemTime,
 };
 
@@ -44,6 +45,84 @@ impl TargetEntry {
             .into_owned()
     }
 
+    /// PROJECT cell text. A linked git worktree reads as `main (tree)`;
+    /// the TUI highlights the `(tree)` tag. Everything else is the dir name.
+    pub fn display_name(&self) -> String {
+        match self.worktree_names() {
+            Some((main, tree)) => format!("{main} ({tree})"),
+            None => self.project_name(),
+        }
+    }
+
+    /// `(main project name, worktree name)` when a linked-worktree `.git`
+    /// file (`gitdir: <main>/.git/worktrees/<tree>`) is found on
+    /// `project_path` or an ancestor. Plain repos (`.git` dir), submodules
+    /// (`.../modules/...`), and unreadable pointers read as `None`.
+    pub fn worktree_names(&self) -> Option<(String, String)> {
+        let mut dir = Some(self.project_path.as_path());
+        while let Some(current) = dir {
+            let git_path = current.join(".git");
+            if git_path.is_dir() {
+                return None;
+            }
+            if git_path.is_file() {
+                return Self::parse_worktree_git_file(&git_path, current);
+            }
+            dir = current.parent();
+        }
+        None
+    }
+
+    fn parse_worktree_git_file(git_path: &Path, git_base: &Path) -> Option<(String, String)> {
+        let text = std::fs::read_to_string(git_path).ok()?;
+        let raw = text.strip_prefix("gitdir:")?.trim();
+        if raw.is_empty() {
+            return None;
+        }
+        let joined = if Path::new(raw).is_absolute() {
+            PathBuf::from(raw)
+        } else {
+            git_base.join(raw)
+        };
+        // Lexical cleanup so `..` in relative gitdirs cannot leak into names.
+        let mut cleaned = PathBuf::new();
+        for comp in joined.components() {
+            match comp {
+                Component::ParentDir => {
+                    cleaned.pop();
+                }
+                Component::CurDir => {}
+                _ => cleaned.push(comp),
+            }
+        }
+        let mut comps = cleaned.components();
+        let mut main = PathBuf::new();
+        let mut found = false;
+        for comp in comps.by_ref() {
+            if matches!(comp, Component::Normal(name) if name.to_string_lossy() == ".git") {
+                found = true;
+                break;
+            }
+            main.push(comp);
+        }
+        if !found {
+            return None;
+        }
+        let is_worktree = matches!(comps.next(), Some(Component::Normal(name)) if name.to_string_lossy() == "worktrees");
+        let tree = match comps.next() {
+            Some(Component::Normal(name)) => name.to_string_lossy().into_owned(),
+            _ => return None,
+        };
+        if !is_worktree {
+            return None;
+        }
+        let main_name = main.file_name()?.to_string_lossy().into_owned();
+        if main_name.is_empty() {
+            return None;
+        }
+        Some((main_name, tree))
+    }
+
     /// Display name for a shared `$CARGO_HOME` dir, if this entry is one.
     pub fn shared_label(&self) -> Option<&'static str> {
         if !self.shared {
@@ -58,4 +137,83 @@ impl TargetEntry {
 
 pub fn resolve_root(raw: &Path) -> PathBuf {
     std::fs::canonicalize(raw).unwrap_or_else(|_| raw.to_path_buf())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::fs;
+
+    fn entry_at(dir: &Path) -> TargetEntry {
+        TargetEntry {
+            project_path: dir.to_path_buf(),
+            target_dir: dir.join("target"),
+            kind: OutputKind::Target,
+            shared: false,
+            size: None,
+            last_modified: None,
+        }
+    }
+
+    #[test]
+    fn linked_worktree_labels_main_and_tree() {
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-label");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("trees/t1")).unwrap();
+        fs::write(
+            root.join("trees/t1/.git"),
+            format!("gitdir: {}/main/.git/worktrees/t1\n", root.display()),
+        )
+        .unwrap();
+        let entry = entry_at(&root.join("trees/t1"));
+        assert_eq!(
+            entry.worktree_names(),
+            Some(("main".to_string(), "t1".to_string()))
+        );
+        // Main name comes from the gitdir, not the checkout dir.
+        assert_eq!(entry.display_name(), "main (t1)");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn nested_crate_in_linked_worktree_labels_main_and_tree() {
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-nested");
+        let _ = fs::remove_dir_all(&root);
+        fs::create_dir_all(root.join("trees/t1/crates/foo")).unwrap();
+        fs::write(
+            root.join("trees/t1/.git"),
+            format!("gitdir: {}/main/.git/worktrees/t1\n", root.display()),
+        )
+        .unwrap();
+        let entry = entry_at(&root.join("trees/t1/crates/foo"));
+        assert_eq!(
+            entry.worktree_names(),
+            Some(("main".to_string(), "t1".to_string()))
+        );
+        assert_eq!(entry.display_name(), "main (t1)");
+        let _ = fs::remove_dir_all(&root);
+    }
+
+    #[test]
+    fn submodule_and_plain_dirs_keep_dir_name() {
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-plain");
+        let _ = fs::remove_dir_all(&root);
+        // Submodule-style pointer targets `modules/`, not `worktrees/`.
+        fs::create_dir_all(root.join("sub")).unwrap();
+        fs::write(root.join("sub/.git"), "gitdir: ../.git/modules/sub\n").unwrap();
+        // Plain repo: `.git` is a dir, unreadable as a pointer file.
+        fs::create_dir_all(root.join("main/.git")).unwrap();
+        fs::create_dir_all(root.join("bare")).unwrap();
+
+        for (dir, name) in [
+            (root.join("sub"), "sub"),
+            (root.join("main"), "main"),
+            (root.join("bare"), "bare"),
+        ] {
+            let entry = entry_at(&dir);
+            assert_eq!(entry.worktree_names(), None);
+            assert_eq!(entry.display_name(), name);
+        }
+        let _ = fs::remove_dir_all(&root);
+    }
 }

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -300,7 +300,8 @@ pub(crate) fn output_suffix(
 }
 
 /// Project cell: shared `$CARGO_HOME` dirs show their special name in the
-/// per-kind highlight color, otherwise the project name plus kind suffix.
+/// per-kind highlight color, otherwise the display name plus kind suffix.
+/// Linked git worktrees render as `main` plus a highlighted `(tree)` tag.
 pub(crate) fn project_spans(
     entry: &crate::scan::TargetEntry,
     entries: &[crate::scan::TargetEntry],
@@ -313,7 +314,13 @@ pub(crate) fn project_spans(
         };
         return vec![Span::styled(shared, base.fg(color))];
     }
-    let mut spans = vec![Span::styled(entry.project_name(), base)];
+    let mut spans = match entry.worktree_names() {
+        Some((main, tree)) => vec![
+            Span::styled(main, base),
+            Span::styled(format!(" ({tree})"), Style::default().fg(Color::Cyan)),
+        ],
+        None => vec![Span::styled(entry.project_name(), base)],
+    };
     if let Some((label, color)) = output_suffix(entry, entries) {
         spans.push(Span::styled(label, Style::default().fg(color)));
     }
@@ -606,6 +613,34 @@ mod tests {
         assert_eq!(spans.len(), 1);
         assert_eq!(spans[0].content.as_ref(), "Shared Build Dir");
         assert_eq!(spans[0].style.fg, Some(Color::Blue));
+    }
+
+    #[test]
+    fn worktree_cells_show_main_name_with_tree_tag() {
+        use crate::scan::{OutputKind, TargetEntry};
+        use ratatui::style::Style;
+        let root = std::env::temp_dir().join("cargo-storage-test-wt-cell");
+        let _ = std::fs::remove_dir_all(&root);
+        std::fs::create_dir_all(root.join("trees/t1")).unwrap();
+        std::fs::write(
+            root.join("trees/t1/.git"),
+            format!("gitdir: {}/main/.git/worktrees/t1\n", root.display()),
+        )
+        .unwrap();
+        let entry = TargetEntry {
+            project_path: root.join("trees/t1"),
+            target_dir: root.join("trees/t1/target"),
+            kind: OutputKind::Target,
+            shared: false,
+            size: None,
+            last_modified: None,
+        };
+        let spans = project_spans(&entry, std::slice::from_ref(&entry), Style::default());
+        assert_eq!(spans.len(), 2);
+        assert_eq!(spans[0].content.as_ref(), "main");
+        assert_eq!(spans[1].content.as_ref(), " (t1)");
+        assert_eq!(spans[1].style.fg, Some(Color::Cyan));
+        let _ = std::fs::remove_dir_all(&root);
     }
 
     #[test]


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Projects in linked Git worktrees are now discovered, including worktrees located in ignored directories.
  * Worktree projects display a clear “(tree)” label in the project list.
  * Project filtering now also matches displayed project names.

* **Bug Fixes**
  * Improved project labels for worktrees while preserving existing labels for regular repositories and submodules.

* **Documentation**
  * Clarified that linked worktrees are included during project scanning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->