### PR TITLE
use spotlight search on macos

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -18,6 +18,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android_system_properties"
+version = "0.1.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae221649c9976a6f6c56ae1facf410f3ddb33cc661c4b7b61020a912d4237fbc"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "anstream"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -140,6 +149,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
 name = "bstr"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -187,6 +205,7 @@ dependencies = [
  "eyre",
  "homedir",
  "ignore",
+ "mdquery-rs",
  "ratatui",
  "rayon",
  "regex",
@@ -206,6 +225,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "cc"
+version = "1.4.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "005ec2760ca554fae18df7a11195552ec576cd665632a881bc011d5bb2fd4d80"
+dependencies = [
+ "find-msvc-tools",
+ "shlex",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -216,6 +245,19 @@ name = "cfg_aliases"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f079e83a288787bcd14a6aea84cee5c87a67c5a3e660c30f557a3d24761b3527"
+
+[[package]]
+name = "chrono"
+version = "0.4.45"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aa79e62e7697b8e29b513a68abacf485adcd1fe8284a4316c5ae868e6633327"
+dependencies = [
+ "iana-time-zone",
+ "js-sys",
+ "num-traits",
+ "wasm-bindgen",
+ "windows-link 0.2.1",
+]
 
 [[package]]
 name = "clap"
@@ -294,6 +336,12 @@ checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
 dependencies = [
  "unicode-segmentation",
 ]
+
+[[package]]
+name = "core-foundation-sys"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpufeatures"
@@ -461,6 +509,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -531,6 +589,12 @@ dependencies = [
  "thiserror 1.0.69",
  "winapi",
 ]
+
+[[package]]
+name = "find-msvc-tools"
+version = "0.1.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e0f1c7c3a72c66fd80abe965175f7523475c0489a87d3ff9d6e8c87d87a9d2d"
 
 [[package]]
 name = "finl_unicode"
@@ -670,6 +734,30 @@ dependencies = [
  "nix 0.30.1",
  "widestring",
  "windows",
+]
+
+[[package]]
+name = "iana-time-zone"
+version = "0.1.65"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+dependencies = [
+ "android_system_properties",
+ "core-foundation-sys",
+ "iana-time-zone-haiku",
+ "js-sys",
+ "log",
+ "wasm-bindgen",
+ "windows-core",
+]
+
+[[package]]
+name = "iana-time-zone-haiku"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f31827a206f56af32e590ba56d5d2d085f558508192593743f16b2306495269f"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -845,6 +933,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "mdquery-rs"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb3c2657427fb64c644e880112852ed69b3931693ec21c90f5e9eac14c32382c"
+dependencies = [
+ "anyhow",
+ "chrono",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
 name = "memchr"
 version = "2.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -961,6 +1061,34 @@ checksum = "5c7398b9c8b70908f6371f47ed36737907c87c52af34c268fed0bf0ceb92ead9"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
 
 [[package]]
 name = "once_cell"
@@ -1472,6 +1600,12 @@ checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
 ]
+
+[[package]]
+name = "shlex"
+version = "2.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8fadd59c855ef2080decdef8ff161eb6661b86933c9d82e5ba29dc602a55aba"
 
 [[package]]
 name = "signal-hook"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,3 +25,6 @@ rayon = "1.12.0"
 clap = { version = "4", features = ["derive"] }
 clap_complete = "4"
 homedir = "0.3.6"
+
+[target.'cfg(target_os = "macos")'.dependencies]
+mdquery-rs = "0.2.1"

--- a/src/scan/cargo_config.rs
+++ b/src/scan/cargo_config.rs
@@ -48,6 +48,18 @@ impl Resolver {
         }
     }
 
+    /// Test seam: `$CARGO_HOME` layer with only `build.build-dir` set.
+    #[cfg(test)]
+    pub(crate) fn with_home_build_dir(build_dir: impl Into<String>) -> Self {
+        let mut r = Self::hermetic();
+        r.home = Some(ConfigFile {
+            base: PathBuf::from("/home/user/.cargo"),
+            target_dir: None,
+            build_dir: Some(build_dir.into()),
+        });
+        r
+    }
+
     /// Candidate output dirs for a manifest dir, most specific last.
     ///
     /// Always includes the default `<manifest>/target` when it differs, so

--- a/src/scan/discover.rs
+++ b/src/scan/discover.rs
@@ -4,6 +4,10 @@
 //! when a parent ignore file prunes them. Projects with
 //! `build.target-dir` / `build.build-dir` in `.cargo/config.toml` report
 //! those dirs instead of `target/`.
+//!
+//! On macOS, discovery can use Spotlight (`mdquery-rs`) to find `Cargo.toml`
+//! files quickly, then filter them to match walk semantics. Set
+//! `CARGO_STORAGE_SPOTLIGHT=0` to force the filesystem walk.
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -14,16 +18,20 @@ use std::{
     },
 };
 
-use ignore::{DirEntry, WalkBuilder, WalkState};
+use ignore::{DirEntry, IncrementalIgnore, WalkBuilder, WalkState};
 use rayon::prelude::*;
 
 use crate::util::cpu_count;
 
 use super::{
     TargetEntry,
-    cargo_config::{DiscoveredEntry, Resolver},
+    cargo_config::{DiscoveredEntry, OutputKind, Resolver},
     measure::{Measurement, measure_target},
 };
+
+#[cfg(target_os = "macos")]
+#[path = "spotlight.rs"]
+mod spotlight;
 
 /// Scan progress messages, sent from the background thread.
 #[derive(Clone, Debug)]
@@ -37,7 +45,7 @@ pub enum ScanEvent {
 }
 
 /// Shared walk state: config cache, known output dirs, manifest dirs.
-struct Ctx {
+pub(crate) struct Ctx {
     resolver: Mutex<Resolver>,
     /// Non-default output dirs to skip descending into. Defaults
     /// (`<proj>/target`) are pruned by name in `keep_entry`, so this stays
@@ -136,8 +144,17 @@ fn walk_ctx(root: &Path, mut resolver: Resolver) -> Arc<Ctx> {
         manifests: Mutex::new(Vec::new()),
         repos: Mutex::new(Vec::new()),
     });
-    run_walk(root, &ctx);
+    run_collect(root, &ctx);
     ctx
+}
+
+/// Discover manifests under `root`, preferring Spotlight on macOS.
+fn run_collect(root: &Path, ctx: &Arc<Ctx>) {
+    #[cfg(target_os = "macos")]
+    if spotlight::collect(root, ctx) {
+        return;
+    }
+    run_walk(root, ctx);
 }
 
 /// Resolve collected manifests into one row per output dir.
@@ -150,13 +167,28 @@ fn finish(ctx: Arc<Ctx>) -> Vec<DiscoveredEntry> {
         repos: _,
     } = Arc::try_unwrap(ctx).map_err(|_| ()).expect("walk done");
     let manifests = manifests.into_inner().unwrap_or_default();
+    let local_targets: HashSet<PathBuf> = manifests
+        .iter()
+        .filter(|m| is_target_dir(&m.join("target")))
+        .cloned()
+        .collect();
     let mut resolver = resolver.into_inner().unwrap_or_else(|_| Resolver::new());
     let mut entries = Vec::new();
     for manifest in &manifests {
         for entry in resolver.resolve(manifest) {
-            if is_target_dir(&entry.target_dir) {
-                entries.push(entry);
+            if !is_target_dir(&entry.target_dir) {
+                continue;
             }
+            // Global `$CARGO_HOME` `build-dir` duplicates dedup unpredictably
+            // when discovery order differs (walk vs Spotlight). A local
+            // `target/` is enough for these projects.
+            if entry.kind == OutputKind::Build
+                && entry.shared
+                && local_targets.contains(&entry.project_path)
+            {
+                continue;
+            }
+            entries.push(entry);
         }
     }
     entries.sort_by(|a, b| {
@@ -334,16 +366,27 @@ fn visit_entry(result: Result<DirEntry, ignore::Error>, ctx: &Ctx) -> WalkState 
         return WalkState::Continue;
     }
     let dir = entry.path();
+    record_repo_if_present(dir, ctx);
+    record_manifest_dir(dir, ctx);
+    WalkState::Continue
+}
+
+/// Whether `dir` holds a git checkout marker.
+pub(crate) fn record_repo_if_present(dir: &Path, ctx: &Ctx) {
     // Any checkout (main or linked) advertises its repo with `.git`.
     // Repos seen here are queried for linked worktrees after the walk,
     // so ancestor scans find worktrees of nested repos too.
-    if std::fs::symlink_metadata(dir.join(".git")).is_ok() {
-        if let Ok(mut repos) = ctx.repos.lock() {
-            repos.push(dir.to_path_buf());
-        }
+    if std::fs::symlink_metadata(dir.join(".git")).is_ok()
+        && let Ok(mut repos) = ctx.repos.lock()
+    {
+        repos.push(dir.to_path_buf());
     }
+}
+
+/// Record one manifest dir and register any custom output dirs for pruning.
+pub(crate) fn record_manifest_dir(dir: &Path, ctx: &Ctx) {
     if !is_manifest_dir(dir) {
-        return WalkState::Continue;
+        return;
     }
     // Fast path: a local `target/` is pruned by name and needs no config
     // I/O, so record the manifest without touching the resolver or customs
@@ -372,7 +415,58 @@ fn visit_entry(result: Result<DirEntry, ignore::Error>, ctx: &Ctx) -> WalkState 
     if let Ok(mut manifests) = ctx.manifests.lock() {
         manifests.push(dir.to_path_buf());
     }
-    WalkState::Continue
+}
+
+/// Ignore matcher mirroring [`run_walk`] gitignore settings.
+pub(crate) fn build_ignore_matcher(root: &Path) -> IncrementalIgnore {
+    WalkBuilder::new(root)
+        .hidden(false)
+        .require_git(false)
+        .build_matchers()
+        .into_iter()
+        .next()
+        .expect("walk builder always yields one matcher")
+}
+
+/// Whether a walk rooted at `root` would reach `manifest_dir`.
+pub(crate) fn spotlight_path_ok(
+    root: &Path,
+    manifest_dir: &Path,
+    ctx: &Ctx,
+    matcher: &mut IncrementalIgnore,
+) -> bool {
+    let rel = manifest_dir.strip_prefix(root).unwrap_or(manifest_dir);
+    if rel.as_os_str().is_empty() {
+        return is_manifest_dir(manifest_dir);
+    }
+    let mut current = PathBuf::new();
+    for component in rel.components() {
+        current.push(component);
+        let name = component.as_os_str().to_str();
+        if matches!(name, Some(".git" | ".cargo")) {
+            return false;
+        }
+        if name == Some("target") {
+            let full = root.join(&current);
+            if is_project_target(&full) {
+                return false;
+            }
+        }
+        if ctx.has_customs.load(Ordering::Relaxed) {
+            let full = root.join(&current);
+            if is_under_customs(ctx, &full) && !is_manifest_dir(&full) {
+                return false;
+            }
+        }
+        if matcher.matched(&current, true).is_ignore() {
+            return false;
+        }
+    }
+    true
+}
+
+pub(crate) fn is_symlink_dir(path: &Path) -> bool {
+    std::fs::symlink_metadata(path).is_ok_and(|md| md.file_type().is_symlink())
 }
 
 /// Whether `path` is a real output dir. Symlinks never count.

--- a/src/scan/discover.rs
+++ b/src/scan/discover.rs
@@ -5,10 +5,11 @@
 //! `build.target-dir` / `build.build-dir` in `.cargo/config.toml` report
 //! those dirs instead of `target/`.
 //!
-//! On macOS, discovery may prefetch manifests from Spotlight (`mdquery-rs`)
-//! before the authoritative filesystem walk. Set `CARGO_STORAGE_SPOTLIGHT=0`
-//! to skip the prefetch. Set `CARGO_STORAGE_SPOTLIGHT_ONLY=1` to use indexed
-//! results without walking (faster, but incomplete when the index lags).
+//! On macOS, discovery uses Spotlight (`mdquery-rs`) to find `Cargo.toml`
+//! files quickly and skips the main filesystem walk when the index returns
+//! hits. Set `CARGO_STORAGE_SPOTLIGHT=0` to force the walk. Set
+//! `CARGO_STORAGE_SPOTLIGHT_WALK=1` to run both (slower, catches unindexed
+//! manifests). Linked worktrees are still walked after Spotlight.
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -149,14 +150,11 @@ fn walk_ctx(root: &Path, mut resolver: Resolver) -> Arc<Ctx> {
     ctx
 }
 
-/// Discover manifests under `root`, optionally prefetching from Spotlight.
+/// Discover manifests under `root`, preferring Spotlight on macOS.
 fn run_collect(root: &Path, ctx: &Arc<Ctx>) {
     #[cfg(target_os = "macos")]
-    {
-        let indexed = spotlight::collect(root, ctx);
-        if indexed && spotlight::only_enabled() {
-            return;
-        }
+    if !spotlight::walk_requested() && spotlight::collect(root, ctx) {
+        return;
     }
     run_walk(root, ctx);
 }
@@ -554,7 +552,6 @@ mod tests {
         let _ = fs::remove_dir_all(&root);
     }
 
-
     #[test]
     fn local_target_and_shared_build_dir_both_listed() {
         let root = std::env::temp_dir().join("cargo-storage-test-local-shared-build");
@@ -570,7 +567,11 @@ mod tests {
             &root,
             Resolver::with_home_build_dir(shared_build.to_string_lossy()),
         );
-        assert_eq!(projects.len(), 2, "local target and shared build-dir: {projects:?}");
+        assert_eq!(
+            projects.len(),
+            2,
+            "local target and shared build-dir: {projects:?}"
+        );
         let build = projects
             .iter()
             .find(|e| e.kind == super::super::OutputKind::Build)

--- a/src/scan/discover.rs
+++ b/src/scan/discover.rs
@@ -5,9 +5,10 @@
 //! `build.target-dir` / `build.build-dir` in `.cargo/config.toml` report
 //! those dirs instead of `target/`.
 //!
-//! On macOS, discovery can use Spotlight (`mdquery-rs`) to find `Cargo.toml`
-//! files quickly, then filter them to match walk semantics. Set
-//! `CARGO_STORAGE_SPOTLIGHT=0` to force the filesystem walk.
+//! On macOS, discovery may prefetch manifests from Spotlight (`mdquery-rs`)
+//! before the authoritative filesystem walk. Set `CARGO_STORAGE_SPOTLIGHT=0`
+//! to skip the prefetch. Set `CARGO_STORAGE_SPOTLIGHT_ONLY=1` to use indexed
+//! results without walking (faster, but incomplete when the index lags).
 use std::{
     collections::HashSet,
     path::{Path, PathBuf},
@@ -25,7 +26,7 @@ use crate::util::cpu_count;
 
 use super::{
     TargetEntry,
-    cargo_config::{DiscoveredEntry, OutputKind, Resolver},
+    cargo_config::{DiscoveredEntry, Resolver},
     measure::{Measurement, measure_target},
 };
 
@@ -148,11 +149,14 @@ fn walk_ctx(root: &Path, mut resolver: Resolver) -> Arc<Ctx> {
     ctx
 }
 
-/// Discover manifests under `root`, preferring Spotlight on macOS.
+/// Discover manifests under `root`, optionally prefetching from Spotlight.
 fn run_collect(root: &Path, ctx: &Arc<Ctx>) {
     #[cfg(target_os = "macos")]
-    if spotlight::collect(root, ctx) {
-        return;
+    {
+        let indexed = spotlight::collect(root, ctx);
+        if indexed && spotlight::only_enabled() {
+            return;
+        }
     }
     run_walk(root, ctx);
 }
@@ -166,29 +170,16 @@ fn finish(ctx: Arc<Ctx>) -> Vec<DiscoveredEntry> {
         manifests,
         repos: _,
     } = Arc::try_unwrap(ctx).map_err(|_| ()).expect("walk done");
-    let manifests = manifests.into_inner().unwrap_or_default();
-    let local_targets: HashSet<PathBuf> = manifests
-        .iter()
-        .filter(|m| is_target_dir(&m.join("target")))
-        .cloned()
-        .collect();
+    let mut manifests = manifests.into_inner().unwrap_or_default();
+    manifests.sort();
+    manifests.dedup();
     let mut resolver = resolver.into_inner().unwrap_or_else(|_| Resolver::new());
     let mut entries = Vec::new();
     for manifest in &manifests {
         for entry in resolver.resolve(manifest) {
-            if !is_target_dir(&entry.target_dir) {
-                continue;
+            if is_target_dir(&entry.target_dir) {
+                entries.push(entry);
             }
-            // Global `$CARGO_HOME` `build-dir` duplicates dedup unpredictably
-            // when discovery order differs (walk vs Spotlight). A local
-            // `target/` is enough for these projects.
-            if entry.kind == OutputKind::Build
-                && entry.shared
-                && local_targets.contains(&entry.project_path)
-            {
-                continue;
-            }
-            entries.push(entry);
         }
     }
     entries.sort_by(|a, b| {
@@ -560,6 +551,39 @@ mod tests {
         assert_eq!(projects.len(), 1);
         assert_eq!(projects[0].project_path, root.join("proj"));
         assert_eq!(projects[0].target_dir, root.join("shared-out"));
+        let _ = fs::remove_dir_all(&root);
+    }
+
+
+    #[test]
+    fn local_target_and_shared_build_dir_both_listed() {
+        let root = std::env::temp_dir().join("cargo-storage-test-local-shared-build");
+        let _ = fs::remove_dir_all(&root);
+        let shared_build = root.join("shared-build");
+        fs::create_dir_all(root.join("proj/target")).unwrap();
+        fs::write(root.join("proj/Cargo.toml"), "[package]\n").unwrap();
+        fs::write(root.join("proj/target/blob.bin"), "hello").unwrap();
+        fs::create_dir_all(&shared_build).unwrap();
+        fs::write(shared_build.join("blob.bin"), "world").unwrap();
+
+        let projects = discover_with(
+            &root,
+            Resolver::with_home_build_dir(shared_build.to_string_lossy()),
+        );
+        assert_eq!(projects.len(), 2, "local target and shared build-dir: {projects:?}");
+        let build = projects
+            .iter()
+            .find(|e| e.kind == super::super::OutputKind::Build)
+            .expect("shared build-dir row");
+        assert_eq!(build.target_dir, shared_build);
+        assert!(build.shared);
+        let target = projects
+            .iter()
+            .find(|e| e.kind == super::super::OutputKind::Target)
+            .expect("local target row");
+        assert_eq!(target.target_dir, root.join("proj/target"));
+        assert!(!target.shared);
+        assert!(projects.iter().all(|e| e.project_path == root.join("proj")));
         let _ = fs::remove_dir_all(&root);
     }
 

--- a/src/scan/spotlight.rs
+++ b/src/scan/spotlight.rs
@@ -1,0 +1,99 @@
+//! macOS Spotlight fast path for `Cargo.toml` discovery.
+//!
+//! Replaces the parallel filesystem walk when the metadata index can answer
+//! `name == Cargo.toml` quickly. Results are filtered to match walk semantics
+//! (gitignores, `.git`/`.cargo` pruning, custom output dirs). On query failure,
+//! an empty index, or `CARGO_STORAGE_SPOTLIGHT=0`, discovery falls back to walk.
+
+use std::path::{Component, Path};
+use std::sync::Arc;
+
+use mdquery_rs::{MDQueryBuilder, MDQueryScope};
+
+use super::{
+    Ctx, build_ignore_matcher, is_symlink_dir, record_manifest_dir, record_repo_if_present,
+    spotlight_path_ok,
+};
+
+/// Env var disabling the Spotlight fast path (`0`, `false`, `no`, `off`).
+pub(crate) const ENV_DISABLE: &str = "CARGO_STORAGE_SPOTLIGHT";
+
+/// Collect manifest dirs under `root` via Spotlight. Returns `true` when the
+/// index was queried and at least one candidate was accepted.
+pub(crate) fn collect(root: &Path, ctx: &Arc<Ctx>) -> bool {
+    if spotlight_disabled() {
+        tracing::debug!("spotlight discovery disabled by {ENV_DISABLE}");
+        return false;
+    }
+    let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
+    let query = MDQueryBuilder::default()
+        .name_is("Cargo.toml")
+        .build(vec![MDQueryScope::Custom(root.clone())], None);
+    let Ok(query) = query else {
+        tracing::debug!("spotlight query build failed, falling back to walk");
+        return false;
+    };
+    let Ok(results) = query.execute() else {
+        tracing::debug!("spotlight query failed, falling back to walk");
+        return false;
+    };
+    if results.is_empty() {
+        tracing::debug!("spotlight returned no Cargo.toml files, falling back to walk");
+        return false;
+    }
+
+    let indexed = results.len();
+    let mut cargo_tomls: Vec<_> = results.into_iter().filter_map(|item| item.path()).collect();
+    // Shallow paths first so custom output dirs register before descendants.
+    cargo_tomls.sort_by_key(|p| p.components().count());
+    let mut matcher = build_ignore_matcher(&root);
+    let mut accepted = 0usize;
+    for cargo_toml in cargo_tomls {
+        let Some(manifest_dir) = cargo_toml.parent() else {
+            continue;
+        };
+        if path_has_component(manifest_dir, ".git") || path_has_component(manifest_dir, ".cargo") {
+            continue;
+        }
+        if is_symlink_dir(manifest_dir) {
+            continue;
+        }
+        if !manifest_dir.starts_with(&root) {
+            continue;
+        }
+        if !spotlight_path_ok(&root, manifest_dir, ctx, &mut matcher) {
+            continue;
+        }
+        for ancestor in manifest_dir.ancestors() {
+            if ancestor.starts_with(&root) {
+                record_repo_if_present(ancestor, ctx);
+            }
+        }
+        record_manifest_dir(manifest_dir, ctx);
+        accepted += 1;
+    }
+    if accepted == 0 {
+        tracing::debug!(
+            count = indexed,
+            "spotlight hits were all filtered out, falling back to walk"
+        );
+        return false;
+    }
+    tracing::info!(indexed, accepted, "spotlight discovery complete");
+    true
+}
+
+fn spotlight_disabled() -> bool {
+    match std::env::var(ENV_DISABLE).as_deref() {
+        Ok("0") | Ok("false") | Ok("no") | Ok("off") | Ok("FALSE") | Ok("OFF") => true,
+        Ok(value) if value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no") => {
+            true
+        }
+        _ => false,
+    }
+}
+
+fn path_has_component(path: &Path, name: &str) -> bool {
+    path.components()
+        .any(|c| matches!(c, Component::Normal(s) if s == name))
+}

--- a/src/scan/spotlight.rs
+++ b/src/scan/spotlight.rs
@@ -1,10 +1,10 @@
-//! macOS Spotlight prefetch for `Cargo.toml` discovery.
+//! macOS Spotlight discovery for `Cargo.toml` files.
 //!
 //! Queries the metadata index for `Cargo.toml` files under `root`, filters
 //! hits to match walk semantics (gitignores, `.git`/`.cargo` pruning, custom
-//! output dirs), and records accepted manifest dirs. The filesystem walk in
-//! [`super::run_collect`] remains authoritative unless
-//! `CARGO_STORAGE_SPOTLIGHT_ONLY=1` opts into indexed-only discovery.
+//! output dirs), and records accepted manifest dirs. When hits are accepted,
+//! [`super::run_collect`] skips the main filesystem walk unless
+//! `CARGO_STORAGE_SPOTLIGHT_WALK=1` requests a full walk as well.
 
 use std::path::{Component, Path};
 use std::sync::Arc;
@@ -18,8 +18,8 @@ use super::{
 
 /// Env var disabling the Spotlight prefetch (`0`, `false`, `no`, `off`).
 pub(crate) const ENV_DISABLE: &str = "CARGO_STORAGE_SPOTLIGHT";
-/// Env var skipping the filesystem walk when the prefetch accepted hits.
-pub(crate) const ENV_ONLY: &str = "CARGO_STORAGE_SPOTLIGHT_ONLY";
+/// Env var forcing a filesystem walk after Spotlight (`1`, `true`, `yes`).
+pub(crate) const ENV_WALK: &str = "CARGO_STORAGE_SPOTLIGHT_WALK";
 
 /// Query Spotlight for `Cargo.toml` under `root` and record accepted manifests.
 /// Returns `true` when at least one candidate was accepted.
@@ -76,19 +76,16 @@ pub(crate) fn collect(root: &Path, ctx: &Arc<Ctx>) -> bool {
         accepted += 1;
     }
     if accepted == 0 {
-        tracing::debug!(
-            count = indexed,
-            "spotlight hits were all filtered out"
-        );
+        tracing::debug!(count = indexed, "spotlight hits were all filtered out");
         return false;
     }
-    tracing::info!(indexed, accepted, "spotlight prefetch complete");
+    tracing::info!(indexed, accepted, "spotlight discovery complete");
     true
 }
 
-/// Whether indexed-only discovery is enabled via `CARGO_STORAGE_SPOTLIGHT_ONLY`.
-pub(crate) fn only_enabled() -> bool {
-    match std::env::var(ENV_ONLY).as_deref() {
+/// Whether a full filesystem walk is requested via `CARGO_STORAGE_SPOTLIGHT_WALK`.
+pub(crate) fn walk_requested() -> bool {
+    match std::env::var(ENV_WALK).as_deref() {
         Ok("0") | Ok("false") | Ok("no") | Ok("off") => false,
         Ok(value) if value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no") => {
             false
@@ -118,7 +115,8 @@ fn spotlight_disabled() -> bool {
 
 /// Whether `path` contains a normal path component equal to `name`.
 fn path_has_component(path: &Path, name: &str) -> bool {
-    path.components().any(|c| matches!(c, Component::Normal(s) if s == name))
+    path.components()
+        .any(|c| matches!(c, Component::Normal(s) if s == name))
 }
 
 fn is_truthy(value: &str) -> bool {

--- a/src/scan/spotlight.rs
+++ b/src/scan/spotlight.rs
@@ -1,9 +1,10 @@
-//! macOS Spotlight fast path for `Cargo.toml` discovery.
+//! macOS Spotlight prefetch for `Cargo.toml` discovery.
 //!
-//! Replaces the parallel filesystem walk when the metadata index can answer
-//! `name == Cargo.toml` quickly. Results are filtered to match walk semantics
-//! (gitignores, `.git`/`.cargo` pruning, custom output dirs). On query failure,
-//! an empty index, or `CARGO_STORAGE_SPOTLIGHT=0`, discovery falls back to walk.
+//! Queries the metadata index for `Cargo.toml` files under `root`, filters
+//! hits to match walk semantics (gitignores, `.git`/`.cargo` pruning, custom
+//! output dirs), and records accepted manifest dirs. The filesystem walk in
+//! [`super::run_collect`] remains authoritative unless
+//! `CARGO_STORAGE_SPOTLIGHT_ONLY=1` opts into indexed-only discovery.
 
 use std::path::{Component, Path};
 use std::sync::Arc;
@@ -15,14 +16,16 @@ use super::{
     spotlight_path_ok,
 };
 
-/// Env var disabling the Spotlight fast path (`0`, `false`, `no`, `off`).
+/// Env var disabling the Spotlight prefetch (`0`, `false`, `no`, `off`).
 pub(crate) const ENV_DISABLE: &str = "CARGO_STORAGE_SPOTLIGHT";
+/// Env var skipping the filesystem walk when the prefetch accepted hits.
+pub(crate) const ENV_ONLY: &str = "CARGO_STORAGE_SPOTLIGHT_ONLY";
 
-/// Collect manifest dirs under `root` via Spotlight. Returns `true` when the
-/// index was queried and at least one candidate was accepted.
+/// Query Spotlight for `Cargo.toml` under `root` and record accepted manifests.
+/// Returns `true` when at least one candidate was accepted.
 pub(crate) fn collect(root: &Path, ctx: &Arc<Ctx>) -> bool {
     if spotlight_disabled() {
-        tracing::debug!("spotlight discovery disabled by {ENV_DISABLE}");
+        tracing::debug!("spotlight prefetch disabled by {ENV_DISABLE}");
         return false;
     }
     let root = std::fs::canonicalize(root).unwrap_or_else(|_| root.to_path_buf());
@@ -30,15 +33,15 @@ pub(crate) fn collect(root: &Path, ctx: &Arc<Ctx>) -> bool {
         .name_is("Cargo.toml")
         .build(vec![MDQueryScope::Custom(root.clone())], None);
     let Ok(query) = query else {
-        tracing::debug!("spotlight query build failed, falling back to walk");
+        tracing::debug!("spotlight query build failed");
         return false;
     };
     let Ok(results) = query.execute() else {
-        tracing::debug!("spotlight query failed, falling back to walk");
+        tracing::debug!("spotlight query failed");
         return false;
     };
     if results.is_empty() {
-        tracing::debug!("spotlight returned no Cargo.toml files, falling back to walk");
+        tracing::debug!("spotlight returned no Cargo.toml files");
         return false;
     }
 
@@ -75,25 +78,52 @@ pub(crate) fn collect(root: &Path, ctx: &Arc<Ctx>) -> bool {
     if accepted == 0 {
         tracing::debug!(
             count = indexed,
-            "spotlight hits were all filtered out, falling back to walk"
+            "spotlight hits were all filtered out"
         );
         return false;
     }
-    tracing::info!(indexed, accepted, "spotlight discovery complete");
+    tracing::info!(indexed, accepted, "spotlight prefetch complete");
     true
 }
 
+/// Whether indexed-only discovery is enabled via `CARGO_STORAGE_SPOTLIGHT_ONLY`.
+pub(crate) fn only_enabled() -> bool {
+    match std::env::var(ENV_ONLY).as_deref() {
+        Ok("0") | Ok("false") | Ok("no") | Ok("off") => false,
+        Ok(value) if value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no") => {
+            false
+        }
+        Ok(value) if value.eq_ignore_ascii_case("off") => false,
+        Ok("") => false,
+        Ok(value) if is_truthy(value) => true,
+        Ok(_) => false,
+        Err(_) => false,
+    }
+}
+
+/// Whether the Spotlight prefetch is disabled via `CARGO_STORAGE_SPOTLIGHT`.
 fn spotlight_disabled() -> bool {
     match std::env::var(ENV_DISABLE).as_deref() {
-        Ok("0") | Ok("false") | Ok("no") | Ok("off") | Ok("FALSE") | Ok("OFF") => true,
-        Ok(value) if value.eq_ignore_ascii_case("false") || value.eq_ignore_ascii_case("no") => {
+        Ok("0") | Ok("false") | Ok("no") | Ok("off") => true,
+        Ok(value)
+            if value.eq_ignore_ascii_case("false")
+                || value.eq_ignore_ascii_case("no")
+                || value.eq_ignore_ascii_case("off") =>
+        {
             true
         }
         _ => false,
     }
 }
 
+/// Whether `path` contains a normal path component equal to `name`.
 fn path_has_component(path: &Path, name: &str) -> bool {
-    path.components()
-        .any(|c| matches!(c, Component::Normal(s) if s == name))
+    path.components().any(|c| matches!(c, Component::Normal(s) if s == name))
+}
+
+fn is_truthy(value: &str) -> bool {
+    matches!(value, "1" | "true" | "yes" | "on" | "TRUE" | "YES" | "ON")
+        || value.eq_ignore_ascii_case("true")
+        || value.eq_ignore_ascii_case("yes")
+        || value.eq_ignore_ascii_case("on")
 }


### PR DESCRIPTION
took advantage of spotlight search's index for very fast searching on MacOS

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * macOS project discovery now uses Spotlight for faster `Cargo.toml` searches.
  * Discovery automatically falls back to filesystem scanning when Spotlight is unavailable or produces no results.
  * Added an environment variable to disable Spotlight discovery when needed.

* **Bug Fixes**
  * Improved filtering of ignored, invalid, symlinked, and out-of-scope directories during discovery.
  * Prevented duplicate or irrelevant shared build directories from being reported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->