### PR TITLE
feat: delete asynchronously

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -326,63 +326,53 @@ impl App {
             .select(Some(i.saturating_sub(self.page_len.max(1))));
     }
 
-    /// Delete the selected project's `target/` dir. A missing dir
-    /// counts as deleted. Failures surface in `delete_error`.
-    /// Selection moves to the row below. Deleting the last row
-    /// keeps selection. A lone row keeps selection.
-    pub fn delete_selected(&mut self) {
+    /// Begin asychronous deletion of the selected entry's `target/` dir.
+    pub fn begin_delete(&mut self) -> Option<PathBuf> {
         self.navigated = true;
         let visible = self.visible_indices();
         let sel = self.table_state.selected();
         let entry_idx = sel.and_then(|i| visible.get(i).copied());
-        let Some(entry_idx) = entry_idx else { return };
+        let Some(entry_idx) = entry_idx else {
+            return None;
+        };
         let Some(target_dir) = self.entries.get(entry_idx).map(|e| e.target_dir.clone()) else {
-            return;
+            return None;
         };
 
         let Some(entry) = self.entries.get_mut(entry_idx) else {
-            return;
+            return None;
         };
-        if entry.is_under_deletion {
+        if entry.is_being_deleted {
             // Exit early if the entry is already being deleted.
-            return;
+            return None;
         }
         // Mark the entry as being deleted.
-        entry.is_under_deletion = true;
+        entry.is_being_deleted = true;
+        Some(target_dir)
+    }
 
-        // TODO: Enqueue `entry.target_path` for asynchronous deletion.
-
-        // Neighbor below by identity, so the resort below cannot lose it.
-        // No row below keeps the current selection.
-        let neighbor_idx = match sel {
-            Some(i) => visible.get(i + 1).copied(),
-            None => None,
-        };
-        let neighbor = neighbor_idx.and_then(|i| self.entries.get(i).map(|e| e.target_dir.clone()));
-        match std::fs::remove_dir_all(&target_dir) {
+    /// Finish asynchronous deletion, processing success or failure.
+    ///
+    /// A missing dir counts as deleted. Failures surface in `delete_error`.
+    /// Selection stays put.
+    pub fn finish_delete(&mut self, target_dir: PathBuf, result: std::io::Result<()>) {
+        match result {
             Ok(()) => self.delete_error = None,
-            Err(e) if e.kind() == std::io::ErrorKind::NotFound => self.delete_error = None,
+            Err(ref e) if e.kind() == std::io::ErrorKind::NotFound => self.delete_error = None,
             Err(e) => {
+                if let Some(entry) = self.entries.iter_mut().find(|e| e.target_dir == target_dir) {
+                    entry.is_being_deleted = false;
+                }
                 self.delete_error = Some(format!("delete {}: {e}", target_dir.display()));
                 return;
             }
         }
+
         if let Some(entry) = self.entries.iter_mut().find(|e| e.target_dir == target_dir) {
             entry.size = Some(0);
             entry.last_modified = None;
         }
         self.total_size = self.entries.iter().filter_map(|e| e.size).sum();
-        if neighbor.is_none() {
-            return;
-        }
-        let visible = self.visible_indices();
-        let pos = visible.iter().position(|&i| {
-            self.entries
-                .get(i)
-                .is_some_and(|e| Some(&e.target_dir) == neighbor.as_ref())
-        });
-        self.table_state
-            .select(pos.or_else(|| visible.first().map(|_| 0)));
     }
 
     /// Select the first row without counting as user navigation, so the
@@ -474,6 +464,14 @@ mod tests {
         // measurements follow the selection instead of pinning to top.
         app.navigated = true;
         app
+    }
+
+    /// Simulate deleting the selected entry's `target_dir` for testing purposes.
+    ///
+    /// Synchronously calls `begin_delete()` then `finish_delete()`.
+    fn simulate_deletion_sync(app: &mut App) {
+        let target_dir = app.begin_delete().expect("selected target");
+        app.finish_delete(target_dir.clone(), std::fs::remove_dir_all(target_dir));
     }
 
     #[test]
@@ -730,7 +728,7 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         app.finish_scan(None);
-        app.delete_selected();
+        simulate_deletion_sync(&mut app);
         assert!(!root.join("proj/target").exists());
         assert_eq!(app.entries[0].size, Some(0));
         assert_eq!(app.entries[0].last_modified, None);
@@ -752,7 +750,7 @@ mod tests {
         app.finish_scan(None);
         app.set_filter("proj-b".to_string());
         assert_eq!(app.visible_indices().len(), 1);
-        app.delete_selected();
+        simulate_deletion_sync(&mut app);
         assert!(!root.join("proj-b/target").exists());
         assert!(root.join("proj-a/target").exists());
         let _ = std::fs::remove_dir_all(&root);
@@ -772,7 +770,7 @@ mod tests {
         // which counts as deleted.
         let mut app = app_with_entries();
         app.table_state.select(Some(0));
-        app.delete_selected();
+        simulate_deletion_sync(&mut app);
         assert_eq!(selected_project(&app), PathBuf::from("proj-small"));
         // Deleting a middle row moves down, not up.
         let mut app = App::new(PathBuf::from("."));
@@ -801,18 +799,18 @@ mod tests {
         app.finish_scan(None);
         app.navigated = true;
         app.table_state.select(Some(1));
-        app.delete_selected();
+        simulate_deletion_sync(&mut app);
         assert_eq!(selected_project(&app), PathBuf::from("proj-small"));
         // Deleting the last row keeps selection on the deleted row.
         let mut app = app_with_entries();
         app.table_state.select(Some(1));
-        app.delete_selected();
+        simulate_deletion_sync(&mut app);
         assert_eq!(app.table_state.selected(), Some(1));
         assert_eq!(selected_project(&app), PathBuf::from("proj-small"));
         // A lone row keeps selection.
         let mut solo = App::new(PathBuf::from("."));
         solo.set_discovered(vec![PathBuf::from("only")]);
-        solo.delete_selected();
+        simulate_deletion_sync(&mut solo);
         assert_eq!(solo.table_state.selected(), Some(0));
     }
 

--- a/src/app.rs
+++ b/src/app.rs
@@ -89,6 +89,7 @@ impl App {
                             shared: found.shared,
                             size: None,
                             last_modified: None,
+                            is_under_deletion: false,
                         });
                     }
                     std::cmp::Ordering::Equal => {
@@ -109,6 +110,7 @@ impl App {
                         shared: found.shared,
                         size: None,
                         last_modified: None,
+                        is_under_deletion: false,
                     });
                 }
                 (Some(_), None) => {
@@ -239,6 +241,7 @@ impl App {
                     shared: false,
                     size: Some(m.size),
                     last_modified: m.last_modified,
+                    is_under_deletion: false,
                 });
             }
         }
@@ -660,7 +663,7 @@ mod tests {
     fn filter_alternation_narrows_to_matches() {
         let mut app = app_with_entries();
         app.set_filter("big|zzz".to_string());
-        assert_eq!(app.visible_indices(), vec![1]);
+        assert_eq!(app.visible_indices(), vec![0]);
         app.set_filter("proj-".to_string());
         assert_eq!(app.visible_indices().len(), 2);
     }
@@ -670,7 +673,7 @@ mod tests {
         let mut app = App::new(PathBuf::from("."));
         app.set_discovered(vec![PathBuf::from("ws/member-a"), PathBuf::from("other")]);
         app.set_filter("member".to_string());
-        assert_eq!(app.visible_indices(), vec![0]);
+        assert_eq!(app.visible_indices(), vec![1]);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -89,7 +89,7 @@ impl App {
                             shared: found.shared,
                             size: None,
                             last_modified: None,
-                            is_under_deletion: false,
+                            is_being_deleted: false,
                         });
                     }
                     std::cmp::Ordering::Equal => {
@@ -110,7 +110,7 @@ impl App {
                         shared: found.shared,
                         size: None,
                         last_modified: None,
-                        is_under_deletion: false,
+                        is_being_deleted: false,
                     });
                 }
                 (Some(_), None) => {
@@ -241,7 +241,7 @@ impl App {
                     shared: false,
                     size: Some(m.size),
                     last_modified: m.last_modified,
-                    is_under_deletion: false,
+                    is_being_deleted: false,
                 });
             }
         }

--- a/src/app.rs
+++ b/src/app.rs
@@ -327,6 +327,8 @@ impl App {
     }
 
     /// Begin asychronous deletion of the selected entry's `target/` dir.
+    ///
+    /// Move selection to the next row, if any.
     pub fn begin_delete(&mut self) -> Option<PathBuf> {
         self.navigated = true;
         let visible = self.visible_indices();
@@ -348,13 +350,16 @@ impl App {
         }
         // Mark the entry as being deleted.
         entry.is_being_deleted = true;
+
+        // Move selection down.
+        self.table_state.select_next();
+
         Some(target_dir)
     }
 
     /// Finish asynchronous deletion, processing success or failure.
     ///
     /// A missing dir counts as deleted. Failures surface in `delete_error`.
-    /// Selection stays put.
     pub fn finish_delete(&mut self, target_dir: PathBuf, result: std::io::Result<()>) {
         match result {
             Ok(()) => self.delete_error = None,
@@ -368,11 +373,39 @@ impl App {
             }
         }
 
-        if let Some(entry) = self.entries.iter_mut().find(|e| e.target_dir == target_dir) {
-            entry.size = Some(0);
-            entry.last_modified = None;
+        if let Some(index) = self
+            .entries
+            .iter()
+            .position(|entry| entry.target_dir == target_dir)
+        {
+            self.mark_entry_deleted(index);
         }
-        self.total_size = self.entries.iter().filter_map(|e| e.size).sum();
+    }
+
+    // Mark an entry as deleted.
+    //
+    // Update `total_size` accordingly.
+    // Keep selection in place by updating its index when necessary.
+    fn mark_entry_deleted(&mut self, index: usize) {
+        // Save visible indices here, because altering the entry might cause changes.
+        let visible_indices = self.visible_indices();
+
+        let entry = &mut self.entries[index];
+
+        // Update the total size.
+        let size = entry.size.unwrap_or(0);
+        self.total_size = self.total_size.saturating_sub(size);
+
+        // Mark the entry as deleted.
+        entry.size = Some(0);
+        entry.last_modified = None;
+
+        // Move the selection up if the entry appeared above it.
+        if let Some(selection_index) = self.table_state.selected()
+            && visible_indices[..selection_index].contains(&index)
+        {
+            self.table_state.select_previous();
+        }
     }
 
     /// Select the first row without counting as user navigation, so the

--- a/src/app.rs
+++ b/src/app.rs
@@ -7,6 +7,7 @@ use crate::scan::{DiscoveredEntry, Measurement, TargetEntry, build_cache_path};
 
 pub struct App {
     pub root: PathBuf,
+    /// Kept sorted by `target_dir`. Sorting and filtering only affect `visible_indices()`.
     pub entries: Vec<TargetEntry>,
     pub build_cache: Option<TargetEntry>,
     pub build_cache_path: Option<PathBuf>,
@@ -54,22 +55,70 @@ impl App {
         }
     }
 
+    /// Merge the results of a scan into `entries`, keeping them sorted.
+    ///
+    /// Incoming `DiscoveredEntry` items are deduplicated on `target_path`.
+    ///
+    /// Current `TargetEntry` and incoming `DiscoveredEntry` items are joined on `target_path`.
+    /// If a `DiscoveredEntry` has *no* matching `TargetEntry`, it is simply added as new.
+    /// If a `DiscoveredEntry` *does* have an existing `TargetEntry`, metadata e.g. `size` are kept.
+    /// If a `TargetEntry` no longer has a matching `DiscoveredEntry`, it is removed.
     pub fn set_discovered(&mut self, discovered: Vec<impl Into<DiscoveredEntry>>) {
-        let entries: Vec<TargetEntry> = discovered
-            .into_iter()
-            .map(|item| {
-                let found: DiscoveredEntry = item.into();
-                TargetEntry {
-                    project_path: found.project_path,
-                    target_dir: found.target_dir,
-                    kind: found.kind,
-                    shared: found.shared,
-                    size: None,
-                    last_modified: None,
+        // Dedup incoming entries.
+        let mut discovered: Vec<DiscoveredEntry> = discovered.into_iter().map(Into::into).collect();
+        discovered.sort_by(|a, b| a.target_dir.cmp(&b.target_dir));
+        discovered.dedup_by(|a, b| a.target_dir == b.target_dir);
+
+        // Merge incoming entries, remove stale entries, and keep metadata where possible.
+        let mut old_entries = std::mem::take(&mut self.entries).into_iter().peekable();
+        let mut discovered = discovered.into_iter().peekable();
+        let mut entries = Vec::with_capacity(old_entries.len() + discovered.len());
+        loop {
+            match (old_entries.peek(), discovered.peek()) {
+                (Some(old), Some(found)) => match old.target_dir.cmp(&found.target_dir) {
+                    std::cmp::Ordering::Less => {
+                        // The target no longer appears in discovery.
+                        old_entries.next();
+                    }
+                    std::cmp::Ordering::Greater => {
+                        let found = discovered.next().expect("peeked entry exists");
+                        entries.push(TargetEntry {
+                            project_path: found.project_path,
+                            target_dir: found.target_dir,
+                            kind: found.kind,
+                            shared: found.shared,
+                            size: None,
+                            last_modified: None,
+                        });
+                    }
+                    std::cmp::Ordering::Equal => {
+                        let mut entry = old_entries.next().expect("peeked entry exists");
+                        let found = discovered.next().expect("peeked entry exists");
+                        entry.project_path = found.project_path;
+                        entry.kind = found.kind;
+                        entry.shared = found.shared;
+                        entries.push(entry);
+                    }
+                },
+                (None, Some(_)) => {
+                    let found = discovered.next().expect("peeked entry exists");
+                    entries.push(TargetEntry {
+                        project_path: found.project_path,
+                        target_dir: found.target_dir,
+                        kind: found.kind,
+                        shared: found.shared,
+                        size: None,
+                        last_modified: None,
+                    });
                 }
-            })
-            .collect();
-        self.total_size = 0;
+                (Some(_), None) => {
+                    // The remaining targets no longer appear in discovery.
+                    break;
+                }
+                (None, None) => break,
+            }
+        }
+        self.total_size = entries.iter().filter_map(|e| e.size).sum();
         self.entries = entries;
         self.scanning = true;
         self.clamp_selection();
@@ -611,7 +660,7 @@ mod tests {
     fn filter_alternation_narrows_to_matches() {
         let mut app = app_with_entries();
         app.set_filter("big|zzz".to_string());
-        assert_eq!(app.visible_indices(), vec![0]);
+        assert_eq!(app.visible_indices(), vec![1]);
         app.set_filter("proj-".to_string());
         assert_eq!(app.visible_indices().len(), 2);
     }

--- a/src/app.rs
+++ b/src/app.rs
@@ -198,11 +198,11 @@ impl App {
         visible
     }
 
-    /// The row at a position in the sorted, filtered table.
-    pub fn visible_entry(&self, position: usize) -> Option<&TargetEntry> {
+    /// The entry at a position in the sorted, filtered table.
+    pub fn visible_entry_mut(&mut self, position: usize) -> Option<&mut TargetEntry> {
         self.visible_indices()
             .get(position)
-            .and_then(|&index| self.entries.get(index))
+            .and_then(|&index| self.entries.get_mut(index))
     }
 
     #[tracing::instrument(skip_all)]
@@ -331,25 +331,18 @@ impl App {
     /// Move selection to the next row, if any.
     pub fn begin_delete(&mut self) -> Option<PathBuf> {
         self.navigated = true;
-        let visible = self.visible_indices();
-        let sel = self.table_state.selected();
-        let entry_idx = sel.and_then(|i| visible.get(i).copied());
-        let Some(entry_idx) = entry_idx else {
-            return None;
-        };
-        let Some(target_dir) = self.entries.get(entry_idx).map(|e| e.target_dir.clone()) else {
-            return None;
-        };
 
-        let Some(entry) = self.entries.get_mut(entry_idx) else {
-            return None;
-        };
+        let sel = self.table_state.selected()?;
+        let entry = self.visible_entry_mut(sel)?;
+
         if entry.is_being_deleted {
             // Exit early if the entry is already being deleted.
             return None;
         }
         // Mark the entry as being deleted.
         entry.is_being_deleted = true;
+
+        let target_dir = entry.target_dir.clone();
 
         // Move selection down.
         self.table_state.select_next();
@@ -519,14 +512,14 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         assert_eq!(
-            app.visible_entry(0).unwrap().project_path,
+            app.visible_entry_mut(0).unwrap().project_path,
             PathBuf::from("proj-small")
         );
         assert_eq!(app.total_size, 300);
         let selected = app
             .table_state
             .selected()
-            .and_then(|i| app.visible_entry(i))
+            .and_then(|i| app.visible_entry_mut(i))
             .unwrap();
         assert_eq!(selected.project_path, PathBuf::from("proj-small"));
         assert_eq!(selected.size, Some(200));
@@ -558,16 +551,16 @@ mod tests {
         }]);
         assert!(app.scanning);
         assert_eq!(app.total_size, 50);
-        assert_eq!(app.visible_entry(0).unwrap().size, None);
+        assert_eq!(app.visible_entry_mut(0).unwrap().size, None);
         assert_eq!(
-            app.visible_entry(1).unwrap().project_path,
+            app.visible_entry_mut(1).unwrap().project_path,
             PathBuf::from("proj-a")
         );
-        assert_eq!(app.visible_entry(1).unwrap().size, Some(50));
+        assert_eq!(app.visible_entry_mut(1).unwrap().size, Some(50));
         // Finishing keeps still-pending rows pending for the poller.
         app.finish_scan(None);
         assert!(!app.scanning);
-        assert_eq!(app.visible_entry(0).unwrap().size, None);
+        assert_eq!(app.visible_entry_mut(0).unwrap().size, None);
     }
     #[test]
     fn fresh_discovery_jumps_to_top() {
@@ -591,7 +584,7 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         assert_eq!(
-            app.visible_entry(0).unwrap().project_path,
+            app.visible_entry_mut(0).unwrap().project_path,
             PathBuf::from("proj-a")
         );
         assert_eq!(app.table_state.selected(), Some(0));
@@ -606,12 +599,12 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         assert_eq!(
-            app.visible_entry(0).unwrap().project_path,
+            app.visible_entry_mut(0).unwrap().project_path,
             PathBuf::from("proj-a")
         );
-        assert_eq!(app.visible_entry(0).unwrap().size, None);
+        assert_eq!(app.visible_entry_mut(0).unwrap().size, None);
         assert_eq!(
-            app.visible_entry(1).unwrap().project_path,
+            app.visible_entry_mut(1).unwrap().project_path,
             PathBuf::from("proj-b")
         );
         // Once everything measures, pure size-desc takes over.
@@ -621,11 +614,11 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         assert_eq!(
-            app.visible_entry(0).unwrap().project_path,
+            app.visible_entry_mut(0).unwrap().project_path,
             PathBuf::from("proj-a")
         );
         assert_eq!(
-            app.visible_entry(1).unwrap().project_path,
+            app.visible_entry_mut(1).unwrap().project_path,
             PathBuf::from("proj-b")
         );
     }
@@ -644,7 +637,7 @@ mod tests {
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
         assert_eq!(
-            app.visible_entry(0).unwrap().project_path,
+            app.visible_entry_mut(0).unwrap().project_path,
             PathBuf::from("proj-b")
         );
         assert_eq!(app.table_state.selected(), Some(0));

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,7 +55,7 @@ impl App {
     }
 
     pub fn set_discovered(&mut self, discovered: Vec<impl Into<DiscoveredEntry>>) {
-        let mut entries: Vec<TargetEntry> = discovered
+        let entries: Vec<TargetEntry> = discovered
             .into_iter()
             .map(|item| {
                 let found: DiscoveredEntry = item.into();
@@ -69,7 +69,6 @@ impl App {
                 }
             })
             .collect();
-        self.sort_entries(&mut entries);
         self.total_size = 0;
         self.entries = entries;
         self.scanning = true;
@@ -84,9 +83,6 @@ impl App {
     pub fn finish_scan(&mut self, build_cache: Option<TargetEntry>) {
         self.build_cache = build_cache;
         self.scanning = false;
-        let mut entries = std::mem::take(&mut self.entries);
-        self.sort_entries(&mut entries);
-        self.entries = entries;
         self.clamp_selection();
     }
 
@@ -103,9 +99,6 @@ impl App {
 
     pub fn cycle_sort(&mut self) {
         self.sort = self.sort.next();
-        let mut entries = std::mem::take(&mut self.entries);
-        self.sort_entries(&mut entries);
-        self.entries = entries;
     }
 
     /// Replace the filter text; an invalid pattern keeps the last good one.
@@ -135,7 +128,7 @@ impl App {
     }
 
     pub fn visible_indices(&self) -> Vec<usize> {
-        match &self.filter_regex {
+        let mut visible: Vec<usize> = match &self.filter_regex {
             None => (0..self.entries.len()).collect(),
             Some(re) => self
                 .entries
@@ -149,7 +142,16 @@ impl App {
                 })
                 .map(|(i, _)| i)
                 .collect(),
-        }
+        };
+        visible.sort_by(|&a, &b| self.compare_entries(&self.entries[a], &self.entries[b]));
+        visible
+    }
+
+    /// The row at a position in the sorted, filtered table.
+    pub fn visible_entry(&self, position: usize) -> Option<&TargetEntry> {
+        self.visible_indices()
+            .get(position)
+            .and_then(|&index| self.entries.get(index))
     }
 
     #[tracing::instrument(skip_all)]
@@ -192,9 +194,6 @@ impl App {
             }
         }
         self.total_size = self.entries.iter().filter_map(|e| e.size).sum();
-        let mut entries = std::mem::take(&mut self.entries);
-        self.sort_entries(&mut entries);
-        self.entries = entries;
         if !self.navigated {
             // Sizes churn the order while the walk runs. Stay glued to the
             // top until the user takes over.
@@ -308,9 +307,6 @@ impl App {
             entry.last_modified = None;
         }
         self.total_size = self.entries.iter().filter_map(|e| e.size).sum();
-        let mut entries = std::mem::take(&mut self.entries);
-        self.sort_entries(&mut entries);
-        self.entries = entries;
         if neighbor.is_none() {
             return;
         }
@@ -334,11 +330,11 @@ impl App {
         }
     }
 
-    fn sort_entries(&self, entries: &mut [TargetEntry]) {
+    fn compare_entries(&self, a: &TargetEntry, b: &TargetEntry) -> std::cmp::Ordering {
         match self.sort {
             // Pending rows float above measured ones: big dirs take
             // longest to measure, so they stay visible while loading.
-            SortKey::Size => entries.sort_by(|a, b| match (a.size, b.size) {
+            SortKey::Size => match (a.size, b.size) {
                 (Some(x), Some(y)) => y.cmp(&x),
                 (Some(_), None) => std::cmp::Ordering::Greater,
                 (None, Some(_)) => std::cmp::Ordering::Less,
@@ -346,9 +342,9 @@ impl App {
                     .project_path
                     .cmp(&b.project_path)
                     .then(a.target_dir.cmp(&b.target_dir)),
-            }),
+            },
             SortKey::Modified => {
-                entries.sort_by(|a, b| match (&a.last_modified, &b.last_modified) {
+                match (&a.last_modified, &b.last_modified) {
                     // Pending and deleted dirs have no timestamp. They sink.
                     (None, None) => a
                         .project_path
@@ -360,13 +356,12 @@ impl App {
                         .cmp(x)
                         .then(a.project_path.cmp(&b.project_path))
                         .then(a.target_dir.cmp(&b.target_dir)),
-                })
+                }
             }
-            SortKey::Name => entries.sort_by(|a, b| {
-                a.project_path
-                    .cmp(&b.project_path)
-                    .then(a.target_dir.cmp(&b.target_dir))
-            }),
+            SortKey::Name => a
+                .project_path
+                .cmp(&b.project_path)
+                .then(a.target_dir.cmp(&b.target_dir)),
         }
     }
 }
@@ -427,13 +422,16 @@ mod tests {
             size: 200,
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
-        assert_eq!(app.entries[0].project_path, PathBuf::from("proj-small"));
+        assert_eq!(
+            app.visible_entry(0).unwrap().project_path,
+            PathBuf::from("proj-small")
+        );
         assert_eq!(app.total_size, 300);
         let selected = app
             .table_state
             .selected()
-            .and_then(|i| app.entries.get(i))
-            .expect("selection kept");
+            .and_then(|i| app.visible_entry(i))
+            .unwrap();
         assert_eq!(selected.project_path, PathBuf::from("proj-small"));
         assert_eq!(selected.size, Some(200));
     }
@@ -464,13 +462,16 @@ mod tests {
         }]);
         assert!(app.scanning);
         assert_eq!(app.total_size, 50);
-        assert_eq!(app.entries[0].size, None);
-        assert_eq!(app.entries[1].project_path, PathBuf::from("proj-a"));
-        assert_eq!(app.entries[1].size, Some(50));
+        assert_eq!(app.visible_entry(0).unwrap().size, None);
+        assert_eq!(
+            app.visible_entry(1).unwrap().project_path,
+            PathBuf::from("proj-a")
+        );
+        assert_eq!(app.visible_entry(1).unwrap().size, Some(50));
         // Finishing keeps still-pending rows pending for the poller.
         app.finish_scan(None);
         assert!(!app.scanning);
-        assert_eq!(app.entries[0].size, None);
+        assert_eq!(app.visible_entry(0).unwrap().size, None);
     }
     #[test]
     fn fresh_discovery_jumps_to_top() {
@@ -493,7 +494,10 @@ mod tests {
             size: 200,
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
-        assert_eq!(app.entries[0].project_path, PathBuf::from("proj-a"));
+        assert_eq!(
+            app.visible_entry(0).unwrap().project_path,
+            PathBuf::from("proj-a")
+        );
         assert_eq!(app.table_state.selected(), Some(0));
     }
     #[test]
@@ -505,17 +509,29 @@ mod tests {
             size: 10,
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
-        assert_eq!(app.entries[0].project_path, PathBuf::from("proj-a"));
-        assert_eq!(app.entries[0].size, None);
-        assert_eq!(app.entries[1].project_path, PathBuf::from("proj-b"));
+        assert_eq!(
+            app.visible_entry(0).unwrap().project_path,
+            PathBuf::from("proj-a")
+        );
+        assert_eq!(app.visible_entry(0).unwrap().size, None);
+        assert_eq!(
+            app.visible_entry(1).unwrap().project_path,
+            PathBuf::from("proj-b")
+        );
         // Once everything measures, pure size-desc takes over.
         app.apply_measurements(&[Measurement {
             target_dir: PathBuf::from("proj-a/target"),
             size: 200,
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
-        assert_eq!(app.entries[0].project_path, PathBuf::from("proj-a"));
-        assert_eq!(app.entries[1].project_path, PathBuf::from("proj-b"));
+        assert_eq!(
+            app.visible_entry(0).unwrap().project_path,
+            PathBuf::from("proj-a")
+        );
+        assert_eq!(
+            app.visible_entry(1).unwrap().project_path,
+            PathBuf::from("proj-b")
+        );
     }
 
     #[test]
@@ -531,7 +547,10 @@ mod tests {
             size: 200,
             last_modified: Some(SystemTime::UNIX_EPOCH),
         }]);
-        assert_eq!(app.entries[0].project_path, PathBuf::from("proj-b"));
+        assert_eq!(
+            app.visible_entry(0).unwrap().project_path,
+            PathBuf::from("proj-b")
+        );
         assert_eq!(app.table_state.selected(), Some(0));
     }
 
@@ -602,7 +621,7 @@ mod tests {
         let mut app = App::new(PathBuf::from("."));
         app.set_discovered(vec![PathBuf::from("ws/member-a"), PathBuf::from("other")]);
         app.set_filter("member".to_string());
-        assert_eq!(app.visible_indices(), vec![1]);
+        assert_eq!(app.visible_indices(), vec![0]);
     }
 
     #[test]

--- a/src/app.rs
+++ b/src/app.rs
@@ -339,6 +339,19 @@ impl App {
         let Some(target_dir) = self.entries.get(entry_idx).map(|e| e.target_dir.clone()) else {
             return;
         };
+
+        let Some(entry) = self.entries.get_mut(entry_idx) else {
+            return;
+        };
+        if entry.is_under_deletion {
+            // Exit early if the entry is already being deleted.
+            return;
+        }
+        // Mark the entry as being deleted.
+        entry.is_under_deletion = true;
+
+        // TODO: Enqueue `entry.target_path` for asynchronous deletion.
+
         // Neighbor below by identity, so the resort below cannot lose it.
         // No row below keeps the current selection.
         let neighbor_idx = match sel {

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -330,6 +330,7 @@ mod tests {
             shared: false,
             size,
             last_modified: age.map(|a| SystemTime::now() - a),
+            is_under_deletion: false,
         }
     }
 
@@ -386,6 +387,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         let rows = [shared.clone()];
         assert_eq!(project_label(&shared, &rows), "Shared Target Dir");

--- a/src/headless.rs
+++ b/src/headless.rs
@@ -330,7 +330,7 @@ mod tests {
             shared: false,
             size,
             last_modified: age.map(|a| SystemTime::now() - a),
-            is_under_deletion: false,
+            is_being_deleted: false,
         }
     }
 
@@ -387,7 +387,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         let rows = [shared.clone()];
         assert_eq!(project_label(&shared, &rows), "Shared Target Dir");

--- a/src/main.rs
+++ b/src/main.rs
@@ -146,6 +146,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
             match event::read().wrap_err("reading terminal event")? {
                 Event::Key(key) => match handle_key(&mut app, key) {
                     Action::Continue => {}
+                    Action::Delete => app.delete_selected(),
                     Action::Quit => return Ok(()),
                     Action::Rescan => {
                         app.begin_scan();

--- a/src/main.rs
+++ b/src/main.rs
@@ -104,6 +104,7 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
     let mut app = App::new(root.clone());
     let mut scan_rx = spawn_scan(&root);
     let mut poller = Poller::new();
+    let delete_worker = DeleteWorker::new();
 
     loop {
         let _frame = tracing::info_span!("frame").entered();
@@ -135,6 +136,10 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
             }
         }
 
+        for done in delete_worker.drain() {
+            app.finish_delete(done.target_dir, done.result);
+        }
+
         poller.poll(&mut app);
         // 60fps while loading, 10fps otherwise.
         let frame_budget = if app.scanning {
@@ -146,7 +151,11 @@ fn run(terminal: &mut Terminal<CrosstermBackend<std::io::Stdout>>, root: PathBuf
             match event::read().wrap_err("reading terminal event")? {
                 Event::Key(key) => match handle_key(&mut app, key) {
                     Action::Continue => {}
-                    Action::Delete => app.delete_selected(),
+                    Action::Delete => {
+                        if let Some(target_dir) = app.begin_delete() {
+                            delete_worker.enqueue(target_dir);
+                        }
+                    }
                     Action::Quit => return Ok(()),
                     Action::Rescan => {
                         app.begin_scan();
@@ -169,4 +178,36 @@ fn spawn_scan(root: &Path) -> Option<mpsc::Receiver<scan::ScanEvent>> {
         scan::scan_stream(&root, tx);
     });
     Some(rx)
+}
+
+struct DeleteDone {
+    target_dir: PathBuf,
+    result: std::io::Result<()>,
+}
+
+struct DeleteWorker {
+    tx: mpsc::Sender<PathBuf>,
+    rx: mpsc::Receiver<DeleteDone>,
+}
+
+impl DeleteWorker {
+    fn new() -> Self {
+        let (tx, requests) = mpsc::channel();
+        let (results, rx) = mpsc::channel();
+        std::thread::spawn(move || {
+            while let Ok(target_dir) = requests.recv() {
+                let result = std::fs::remove_dir_all(&target_dir);
+                let _ = results.send(DeleteDone { target_dir, result });
+            }
+        });
+        Self { tx, rx }
+    }
+
+    fn enqueue(&self, target_dir: PathBuf) {
+        let _ = self.tx.send(target_dir);
+    }
+
+    fn drain(&self) -> impl Iterator<Item = DeleteDone> + '_ {
+        std::iter::from_fn(|| self.rx.try_recv().ok())
+    }
 }

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -33,7 +33,7 @@ pub fn build_cache_entry_at(path: &Path) -> Option<TargetEntry> {
         shared: false,
         size: Some(size),
         last_modified,
-        is_under_deletion: false,
+        is_being_deleted: false,
     })
 }
 

--- a/src/scan/cache.rs
+++ b/src/scan/cache.rs
@@ -33,6 +33,7 @@ pub fn build_cache_entry_at(path: &Path) -> Option<TargetEntry> {
         shared: false,
         size: Some(size),
         last_modified,
+        is_under_deletion: false,
     })
 }
 

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -34,6 +34,8 @@ pub struct TargetEntry {
     pub size: Option<u64>,
     /// Newest mtime under `target_dir`, or `None` while pending or deleted.
     pub last_modified: Option<SystemTime>,
+    /// True while the target directory is queued for deletion or being deleted.
+    pub is_under_deletion: bool,
 }
 
 impl TargetEntry {
@@ -152,6 +154,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         }
     }
 

--- a/src/scan/mod.rs
+++ b/src/scan/mod.rs
@@ -35,7 +35,7 @@ pub struct TargetEntry {
     /// Newest mtime under `target_dir`, or `None` while pending or deleted.
     pub last_modified: Option<SystemTime>,
     /// True while the target directory is queued for deletion or being deleted.
-    pub is_under_deletion: bool,
+    pub is_being_deleted: bool,
 }
 
 impl TargetEntry {
@@ -154,7 +154,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         }
     }
 

--- a/src/ui/input.rs
+++ b/src/ui/input.rs
@@ -5,6 +5,7 @@ use crate::app::App;
 /// What the event loop should do after a key press.
 pub enum Action {
     Continue,
+    Delete,
     Quit,
     Rescan,
 }
@@ -80,10 +81,7 @@ pub fn handle_key(app: &mut App, key: KeyEvent) -> Action {
             app.cycle_sort();
             Action::Continue
         }
-        (KeyCode::Char('d'), _) => {
-            app.delete_selected();
-            Action::Continue
-        }
+        (KeyCode::Char('d'), _) => Action::Delete,
         (KeyCode::Char('r'), _) => Action::Rescan,
         _ => Action::Continue,
     }
@@ -144,7 +142,7 @@ mod tests {
     }
 
     #[test]
-    fn d_deletes_selected_target() {
+    fn d_requests_deletion() {
         let root = std::env::temp_dir().join("cargo-storage-test-input-delete");
         let _ = std::fs::remove_dir_all(&root);
         std::fs::create_dir_all(root.join("proj/target")).unwrap();
@@ -152,9 +150,9 @@ mod tests {
         app.set_discovered(vec![root.join("proj")]);
         assert!(matches!(
             handle_key(&mut app, key(KeyCode::Char('d'))),
-            Action::Continue
+            Action::Delete
         ));
-        assert!(!root.join("proj/target").exists());
+        assert!(root.join("proj/target").exists());
         let _ = std::fs::remove_dir_all(&root);
     }
 

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -121,7 +121,7 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 };
                 let spans = project_spans(e, &app.entries, base);
                 let name = Text::from(Line::from(spans));
-                let mut size_text = if e.is_under_deletion {
+                let mut size_text = if e.is_being_deleted {
                     Text::styled("DELETING...", Style::default().fg(crate::ui::theme::AMBER))
                 } else {
                     match e.size {
@@ -525,7 +525,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         assert_eq!(format_modified_entry(&pending), "-");
     }
@@ -539,7 +539,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         let pair = vec![
             entry("tout", OutputKind::Target),
@@ -565,7 +565,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         assert_eq!(output_suffix(&only, std::slice::from_ref(&only)), None);
         // Same path twice is one row, not a pair.
@@ -585,7 +585,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         assert_eq!(
             shared(OutputKind::Target).shared_label(),
@@ -613,7 +613,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         let target = entry(OutputKind::Target);
         let spans = project_spans(&target, std::slice::from_ref(&target), Style::default());
@@ -646,7 +646,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
-            is_under_deletion: false,
+            is_being_deleted: false,
         };
         let spans = project_spans(&entry, std::slice::from_ref(&entry), Style::default());
         assert_eq!(spans.len(), 2);

--- a/src/ui/mod.rs
+++ b/src/ui/mod.rs
@@ -121,12 +121,19 @@ pub fn render(frame: &mut Frame, app: &mut App) {
                 };
                 let spans = project_spans(e, &app.entries, base);
                 let name = Text::from(Line::from(spans));
-                let mut size_text = match e.size {
-                    Some(_) => Text::styled(format_size_opt(e.size), size_style(e.size)),
-                    None => Text::from(
-                        crate::ui::loading::Loading::new("Loading...", app.loading_start.elapsed())
+                let mut size_text = if e.is_under_deletion {
+                    Text::styled("DELETING...", Style::default().fg(crate::ui::theme::AMBER))
+                } else {
+                    match e.size {
+                        Some(_) => Text::styled(format_size_opt(e.size), size_style(e.size)),
+                        None => Text::from(
+                            crate::ui::loading::Loading::new(
+                                "Loading...",
+                                app.loading_start.elapsed(),
+                            )
                             .line(),
-                    ),
+                        ),
+                    }
                 };
                 size_text.alignment = Some(Alignment::Right);
                 let mut row = Row::new([
@@ -518,6 +525,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         assert_eq!(format_modified_entry(&pending), "-");
     }
@@ -531,6 +539,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         let pair = vec![
             entry("tout", OutputKind::Target),
@@ -556,6 +565,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         assert_eq!(output_suffix(&only, std::slice::from_ref(&only)), None);
         // Same path twice is one row, not a pair.
@@ -575,6 +585,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         assert_eq!(
             shared(OutputKind::Target).shared_label(),
@@ -602,6 +613,7 @@ mod tests {
             shared: true,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         let target = entry(OutputKind::Target);
         let spans = project_spans(&target, std::slice::from_ref(&target), Style::default());
@@ -634,6 +646,7 @@ mod tests {
             shared: false,
             size: None,
             last_modified: None,
+            is_under_deletion: false,
         };
         let spans = project_spans(&entry, std::slice::from_ref(&entry), Style::default());
         assert_eq!(spans.len(), 2);


### PR DESCRIPTION
Closes #8.

- Refactor `App` so `entries: Vec<TargetEntry>` preserves metadata across scans.
  - Keep `entries` sorted and deduplicated on `target_path`.
  - Merge new scan results in `set_discovered()` while preserving existing metadata (size, timestamp, etc).
- Extend `TargetEntry` with `is_being_deleted: bool`.
- Show `DELETING...` instead of size while an entry is under deletion.
- Add a FIFO `DeleteWorker` that performs filesystem deletions off the UI thread.
- Make input emit `Action::Delete` for the delete command.
- Split `App`-side deletion bookkeeping into `begin_delete()` and `finish_delete()`.
- On `Action::Delete`, call `begin_delete()` to mark the entry and enqueue its target.
- On `DeleteDone`, call `finish_delete()` to mark entries as deleted (size = 0, no timestamp) or show errors.